### PR TITLE
Use trailing zeros in bitmap to_array conversion

### DIFF
--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -203,7 +203,7 @@ impl Store {
                 for (index, mut bit) in bits.iter().cloned().enumerate() {
                     while bit != 0 {
                         vec.push((u64::trailing_zeros(bit) + (64 * index as u32)) as u16);
-                        bit = bit ^ (1 << u64::trailing_zeros(bit));
+                        bit &= bit - 1;
                     }
                 }
                 Array(vec)

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -200,11 +200,10 @@ impl Store {
             Array(..) => panic!("Cannot convert array to array"),
             Bitmap(ref bits) => {
                 let mut vec = Vec::new();
-                for (key, val) in bits.iter().cloned().enumerate().filter(|&(_, v)| v != 0) {
-                    for bit in 0..64 {
-                        if (val & (1 << bit)) != 0 {
-                            vec.push(key as u16 * 64 + bit as u16);
-                        }
+                for (index, mut bit) in bits.iter().cloned().enumerate() {
+                    while bit != 0 {
+                        vec.push((u64::trailing_zeros(bit) + (64 * index as u32)) as u16);
+                        bit = bit ^ (1 << u64::trailing_zeros(bit));
                     }
                 }
                 Array(vec)


### PR DESCRIPTION
This PR implements an optimization on bitmap to_array conversion by utilizing the trailing_zeros method. 

Curious if theres a good reason to not implement it this way. Im still learning rust so let me know if this looks off.

this version is faster when there are gaps between set bits and performs about the same when all 64 bits are set.
cc: @Nemo157 