### PR TITLE
bugfix:deserialize:cotainers max len should be 2^16+1

### DIFF
--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -130,7 +130,7 @@ impl RoaringBitmap {
             }
         };
 
-        if size > u16::max_value() as usize {
+        if size > u32::max_value() as usize {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 "size is greater than supported",

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -130,7 +130,7 @@ impl RoaringBitmap {
             }
         };
 
-        if size > u32::max_value() as usize {
+        if size > u16::max_value() as usize + 1 {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 "size is greater than supported",

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -74,6 +74,23 @@ fn test_bitmap_boundary() {
     assert_eq!(original, new);
 }
 
+
+#[test]
+fn test_bitmap_high16bits() {
+    let mut bitmap = RoaringBitmap::new();
+    for i in 0..1<<16 {
+        let value = i << 16;
+        bitmap.insert(value);
+    }
+
+    let mut buffer = vec![];
+    bitmap.serialize_into(&mut buffer).unwrap();
+
+    let new = RoaringBitmap::deserialize_from(&mut &buffer[..]);
+    assert_eq!(true, new.is_ok());
+    assert_eq!(bitmap, new.unwrap());
+}
+
 #[test]
 fn test_bitmap() {
     let original = RoaringBitmap::from_iter(1000..6000);

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -78,7 +78,7 @@ fn test_bitmap_boundary() {
 #[test]
 fn test_bitmap_high16bits() {
     let mut bitmap = RoaringBitmap::new();
-    for i in 0..1<<16 {
+    for i in 0..1 << 16 {
         let value = i << 16;
         bitmap.insert(value);
     }

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -74,7 +74,6 @@ fn test_bitmap_boundary() {
     assert_eq!(original, new);
 }
 
-
 #[test]
 fn test_bitmap_high16bits() {
     let mut bitmap = RoaringBitmap::new();


### PR DESCRIPTION
Hello.

RoaringBitmap's cotainers max len should be ~u32::max_value()~ u16::max_value() + 1 rather then u16 in deserialize.