### PR TITLE
Allow using from_iter instead of collect

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets -- -D warnings
+          args: --all-targets

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![warn(missing_docs)]
 #![warn(variant_size_differences)]
-#![allow(unknown_lints)] // For clippy
+#![allow(unknown_lints, clippy::from_iter_instead_of_collect)] // For clippy
 
 extern crate byteorder;
 

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/difference_with.rs
+++ b/tests/difference_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/intersect_with.rs
+++ b/tests/intersect_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/is_disjoint.rs
+++ b/tests/is_disjoint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/is_subset.rs
+++ b/tests/is_subset.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/ops.rs
+++ b/tests/ops.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::{RoaringBitmap, RoaringTreemap};
 use std::iter::FromIterator;

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 
 use std::iter::FromIterator;

--- a/tests/size_hint.rs
+++ b/tests/size_hint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/symmetric_difference_with.rs
+++ b/tests/symmetric_difference_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 

--- a/tests/treemap_clone.rs
+++ b/tests/treemap_clone.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_difference_with.rs
+++ b/tests/treemap_difference_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_intersect_with.rs
+++ b/tests/treemap_intersect_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_is_disjoint.rs
+++ b/tests/treemap_is_disjoint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_is_subset.rs
+++ b/tests/treemap_is_subset.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_lib.rs
+++ b/tests/treemap_lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_ops.rs
+++ b/tests/treemap_ops.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_size_hint.rs
+++ b/tests/treemap_size_hint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_symmetric_difference_with.rs
+++ b/tests/treemap_symmetric_difference_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/treemap_union_with.rs
+++ b/tests/treemap_union_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringTreemap;
 

--- a/tests/union_with.rs
+++ b/tests/union_with.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_iter_instead_of_collect)]
+
 extern crate roaring;
 use roaring::RoaringBitmap;
 


### PR DESCRIPTION
Clippy started warning that we use from_iter instead of collect, but why not just letting us do that.