### PR TITLE
test: use collect() over from_iter()

### DIFF
--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -90,7 +90,7 @@ impl RoaringBitmap {
     /// use roaring::RoaringBitmap;
     /// use std::iter::FromIterator;
     ///
-    /// let bitmap = RoaringBitmap::from_iter(1..3);
+    /// let bitmap = (1..3).collect::<RoaringBitmap>();
     /// let mut iter = bitmap.iter();
     ///
     /// assert_eq!(iter.next(), Some(1));

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -158,7 +158,7 @@ impl RoaringTreemap {
     /// let original = RoaringTreemap::from_iter(0..6000);
     /// let mut bitmaps = original.bitmaps();
     ///
-    /// assert_eq!(bitmaps.next(), Some((0, &RoaringBitmap::from_iter(0..6000))));
+    /// assert_eq!(bitmaps.next(), Some((0, &(0..6000).collect::<RoaringBitmap>())));
     /// assert_eq!(bitmaps.next(), None);
     /// ```
     pub fn bitmaps(&self) -> BitmapIter {

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let original = RoaringBitmap::from_iter(0..2000);
+    let original = (0..2000).collect::<RoaringBitmap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -13,7 +13,7 @@ fn array() {
 
 #[test]
 fn bitmap() {
-    let original = RoaringBitmap::from_iter(0..6000);
+    let original = (0..6000).collect::<RoaringBitmap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);

--- a/tests/difference_with.rs
+++ b/tests/difference_with.rs
@@ -5,9 +5,9 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..3000);
-    let bitmap3 = RoaringBitmap::from_iter(0..1000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..1000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -16,8 +16,8 @@ fn array() {
 
 #[test]
 fn no_difference() {
-    let mut bitmap1 = RoaringBitmap::from_iter(1..3);
-    let bitmap2 = RoaringBitmap::from_iter(1..3);
+    let mut bitmap1 = (1..3).collect::<RoaringBitmap>();
+    let bitmap2 = (1..3).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -26,9 +26,9 @@ fn no_difference() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..8000);
-    let bitmap3 = RoaringBitmap::from_iter(0..1000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..1000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -37,9 +37,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap_to_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(6000..18000);
-    let bitmap3 = RoaringBitmap::from_iter(0..6000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..6000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -48,9 +48,9 @@ fn bitmap_to_bitmap() {
 
 #[test]
 fn bitmap_to_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..6000);
-    let bitmap2 = RoaringBitmap::from_iter(3000..9000);
-    let bitmap3 = RoaringBitmap::from_iter(0..3000);
+    let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
+    let bitmap2 = (3000..9000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..3000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -59,9 +59,9 @@ fn bitmap_to_array() {
 
 #[test]
 fn bitmap_and_array_to_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(9000..12000);
-    let bitmap3 = RoaringBitmap::from_iter(0..9000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (9000..12000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..9000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -70,9 +70,9 @@ fn bitmap_and_array_to_bitmap() {
 
 #[test]
 fn bitmap_and_array_to_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..6000);
-    let bitmap2 = RoaringBitmap::from_iter(3000..6000);
-    let bitmap3 = RoaringBitmap::from_iter(0..3000);
+    let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
+    let bitmap2 = (3000..6000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..3000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 

--- a/tests/intersect_with.rs
+++ b/tests/intersect_with.rs
@@ -5,9 +5,9 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..3000);
-    let bitmap3 = RoaringBitmap::from_iter(1000..2000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
+    let bitmap3 = (1000..2000).collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 
@@ -16,8 +16,8 @@ fn array() {
 
 #[test]
 fn no_intersection() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2);
-    let bitmap2 = RoaringBitmap::from_iter(3..4);
+    let mut bitmap1 = (0..2).collect::<RoaringBitmap>();
+    let bitmap2 = (3..4).collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 
@@ -26,9 +26,9 @@ fn no_intersection() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..8000);
-    let bitmap3 = RoaringBitmap::from_iter(1000..2000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
+    let bitmap3 = (1000..2000).collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 
@@ -37,9 +37,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap_to_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(6000..18000);
-    let bitmap3 = RoaringBitmap::from_iter(6000..12000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
+    let bitmap3 = (6000..12000).collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 
@@ -48,9 +48,9 @@ fn bitmap_to_bitmap() {
 
 #[test]
 fn bitmap_to_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..6000);
-    let bitmap2 = RoaringBitmap::from_iter(3000..9000);
-    let bitmap3 = RoaringBitmap::from_iter(3000..6000);
+    let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
+    let bitmap2 = (3000..9000).collect::<RoaringBitmap>();
+    let bitmap3 = (3000..6000).collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 
@@ -59,9 +59,9 @@ fn bitmap_to_array() {
 
 #[test]
 fn bitmap_and_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(7000..9000);
-    let bitmap3 = RoaringBitmap::from_iter(7000..9000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (7000..9000).collect::<RoaringBitmap>();
+    let bitmap3 = (7000..9000).collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 

--- a/tests/is_disjoint.rs
+++ b/tests/is_disjoint.rs
@@ -5,29 +5,29 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(4000..6000);
+    let bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (4000..6000).collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn array_not() {
-    let bitmap1 = RoaringBitmap::from_iter(0..4000);
-    let bitmap2 = RoaringBitmap::from_iter(2000..6000);
+    let bitmap1 = (0..4000).collect::<RoaringBitmap>();
+    let bitmap2 = (2000..6000).collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }
 
 #[test]
 fn bitmap() {
-    let bitmap1 = RoaringBitmap::from_iter(0..6000);
-    let bitmap2 = RoaringBitmap::from_iter(10000..16000);
+    let bitmap1 = (0..6000).collect::<RoaringBitmap>();
+    let bitmap2 = (10000..16000).collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn bitmap_not() {
-    let bitmap1 = RoaringBitmap::from_iter(0..10000);
-    let bitmap2 = RoaringBitmap::from_iter(5000..15000);
+    let bitmap1 = (0..10000).collect::<RoaringBitmap>();
+    let bitmap2 = (5000..15000).collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }
 

--- a/tests/is_subset.rs
+++ b/tests/is_subset.rs
@@ -5,50 +5,50 @@ use std::iter::FromIterator;
 
 #[test]
 fn array_not() {
-    let sup = RoaringBitmap::from_iter(0..2000);
-    let sub = RoaringBitmap::from_iter(1000..3000);
+    let sup = (0..2000).collect::<RoaringBitmap>();
+    let sub = (1000..3000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), false);
 }
 
 #[test]
 fn array() {
-    let sup = RoaringBitmap::from_iter(0..4000);
-    let sub = RoaringBitmap::from_iter(2000..3000);
+    let sup = (0..4000).collect::<RoaringBitmap>();
+    let sub = (2000..3000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), true);
 }
 
 #[test]
 fn array_bitmap_not() {
-    let sup = RoaringBitmap::from_iter(0..2000);
-    let sub = RoaringBitmap::from_iter(1000..15000);
+    let sup = (0..2000).collect::<RoaringBitmap>();
+    let sub = (1000..15000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), false);
 }
 
 #[test]
 fn bitmap_not() {
-    let sup = RoaringBitmap::from_iter(0..6000);
-    let sub = RoaringBitmap::from_iter(4000..10000);
+    let sup = (0..6000).collect::<RoaringBitmap>();
+    let sub = (4000..10000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), false);
 }
 
 #[test]
 fn bitmap() {
-    let sup = RoaringBitmap::from_iter(0..20000);
-    let sub = RoaringBitmap::from_iter(5000..15000);
+    let sup = (0..20000).collect::<RoaringBitmap>();
+    let sub = (5000..15000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), true);
 }
 
 #[test]
 fn bitmap_array_not() {
-    let sup = RoaringBitmap::from_iter(0..20000);
-    let sub = RoaringBitmap::from_iter(19000..21000);
+    let sup = (0..20000).collect::<RoaringBitmap>();
+    let sub = (19000..21000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), false);
 }
 
 #[test]
 fn bitmap_array() {
-    let sup = RoaringBitmap::from_iter(0..20000);
-    let sub = RoaringBitmap::from_iter(18000..20000);
+    let sup = (0..20000).collect::<RoaringBitmap>();
+    let sub = (18000..20000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), true);
 }
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let original = RoaringBitmap::from_iter(0..2000);
+    let original = (0..2000).collect::<RoaringBitmap>();
     let clone = RoaringBitmap::from_iter(&original);
     let clone2 = RoaringBitmap::from_iter(original.clone());
 
@@ -15,7 +15,7 @@ fn array() {
 
 #[test]
 fn bitmap() {
-    let original = RoaringBitmap::from_iter(0..6000);
+    let original = (0..6000).collect::<RoaringBitmap>();
     let clone = RoaringBitmap::from_iter(&original);
     let clone2 = RoaringBitmap::from_iter(original.clone());
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -66,7 +66,7 @@ fn remove_range() {
 #[test]
 #[allow(clippy::range_plus_one)] // remove_range needs an exclusive range
 fn remove_range_array() {
-    let mut bitmap = RoaringBitmap::from_iter(0..1000);
+    let mut bitmap = (0..1000).collect::<RoaringBitmap>();
     for i in 0..1000 {
         assert_eq!(bitmap.remove_range(i..i), 0);
         assert_eq!(bitmap.remove_range(i..i + 1), 1);
@@ -80,7 +80,7 @@ fn remove_range_array() {
     }
 
     // remove [0, 2), [2, 4), ..
-    let mut bitmap = RoaringBitmap::from_iter(0..1000);
+    let mut bitmap = (0..1000).collect::<RoaringBitmap>();
     for i in 0..1000 / 2 {
         assert_eq!(bitmap.remove_range(i * 2..(i + 1) * 2), 2);
     }
@@ -117,7 +117,7 @@ fn remove_range_bitmap() {
 
 #[test]
 fn to_bitmap() {
-    let bitmap = RoaringBitmap::from_iter(0..5000);
+    let bitmap = (0..5000).collect::<RoaringBitmap>();
     assert_eq!(bitmap.len(), 5000);
     for i in 1..5000 {
         assert_eq!(bitmap.contains(i), true);
@@ -127,7 +127,7 @@ fn to_bitmap() {
 
 #[test]
 fn to_array() {
-    let mut bitmap = RoaringBitmap::from_iter(0..5000);
+    let mut bitmap = (0..5000).collect::<RoaringBitmap>();
     for i in 3000..5000 {
         bitmap.remove(i);
     }

--- a/tests/ops.rs
+++ b/tests/ops.rs
@@ -5,9 +5,9 @@ use std::iter::FromIterator;
 
 #[test]
 fn or() {
-    let mut rb1 = RoaringBitmap::from_iter(1..4);
-    let rb2 = RoaringBitmap::from_iter(3..6);
-    let rb3 = RoaringBitmap::from_iter(1..6);
+    let mut rb1 = (1..4).collect::<RoaringBitmap>();
+    let rb2 = (3..6).collect::<RoaringBitmap>();
+    let rb3 = (1..6).collect::<RoaringBitmap>();
 
     assert_eq!(rb3, &rb1 | &rb2);
     assert_eq!(rb3, &rb1 | rb2.clone());
@@ -22,9 +22,9 @@ fn or() {
 
 #[test]
 fn and() {
-    let mut rb1 = RoaringBitmap::from_iter(1..4);
-    let rb2 = RoaringBitmap::from_iter(3..6);
-    let rb3 = RoaringBitmap::from_iter(3..4);
+    let mut rb1 = (1..4).collect::<RoaringBitmap>();
+    let rb2 = (3..6).collect::<RoaringBitmap>();
+    let rb3 = (3..4).collect::<RoaringBitmap>();
 
     assert_eq!(rb3, &rb1 & &rb2);
     assert_eq!(rb3, &rb1 & rb2.clone());
@@ -39,9 +39,9 @@ fn and() {
 
 #[test]
 fn sub() {
-    let mut rb1 = RoaringBitmap::from_iter(1..4);
-    let rb2 = RoaringBitmap::from_iter(3..6);
-    let rb3 = RoaringBitmap::from_iter(1..3);
+    let mut rb1 = (1..4).collect::<RoaringBitmap>();
+    let rb2 = (3..6).collect::<RoaringBitmap>();
+    let rb3 = (1..3).collect::<RoaringBitmap>();
 
     assert_eq!(rb3, &rb1 - &rb2);
     assert_eq!(rb3, &rb1 - rb2.clone());
@@ -56,10 +56,10 @@ fn sub() {
 
 #[test]
 fn xor() {
-    let mut rb1 = RoaringBitmap::from_iter(1..4);
-    let rb2 = RoaringBitmap::from_iter(3..6);
+    let mut rb1 = (1..4).collect::<RoaringBitmap>();
+    let rb2 = (3..6).collect::<RoaringBitmap>();
     let rb3 = RoaringBitmap::from_iter((1..3).chain(4..6));
-    let rb4 = RoaringBitmap::from_iter(0..0);
+    let rb4 = (0..0).collect::<RoaringBitmap>();
 
     assert_eq!(rb3, &rb1 ^ &rb2);
     assert_eq!(rb3, &rb1 ^ rb2.clone());

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -48,28 +48,28 @@ fn test_empty() {
 
 #[test]
 fn test_one() {
-    let original = RoaringBitmap::from_iter(1..2);
+    let original = (1..2).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
 
 #[test]
 fn test_array() {
-    let original = RoaringBitmap::from_iter(1000..3000);
+    let original = (1000..3000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
 
 #[test]
 fn test_array_boundary() {
-    let original = RoaringBitmap::from_iter(1000..5096);
+    let original = (1000..5096).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
 
 #[test]
 fn test_bitmap_boundary() {
-    let original = RoaringBitmap::from_iter(1000..5097);
+    let original = (1000..5097).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
@@ -92,7 +92,7 @@ fn test_bitmap_high16bits() {
 
 #[test]
 fn test_bitmap() {
-    let original = RoaringBitmap::from_iter(1000..6000);
+    let original = (1000..6000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }

--- a/tests/size_hint.rs
+++ b/tests/size_hint.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let bitmap = RoaringBitmap::from_iter(0..2000);
+    let bitmap = (0..2000).collect::<RoaringBitmap>();
     let mut iter = bitmap.iter();
     assert_eq!((2000, Some(2000)), iter.size_hint());
     iter.by_ref().take(1000).for_each(drop);
@@ -16,7 +16,7 @@ fn array() {
 
 #[test]
 fn bitmap() {
-    let bitmap = RoaringBitmap::from_iter(0..6000);
+    let bitmap = (0..6000).collect::<RoaringBitmap>();
     let mut iter = bitmap.iter();
     assert_eq!((6000, Some(6000)), iter.size_hint());
     iter.by_ref().take(3000).for_each(drop);

--- a/tests/symmetric_difference_with.rs
+++ b/tests/symmetric_difference_with.rs
@@ -5,8 +5,8 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..3000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
     let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(2000..3000));
 
     bitmap1.symmetric_difference_with(&bitmap2);
@@ -16,8 +16,8 @@ fn array() {
 
 #[test]
 fn no_symmetric_difference() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2);
-    let bitmap2 = RoaringBitmap::from_iter(0..2);
+    let mut bitmap1 = (0..2).collect::<RoaringBitmap>();
+    let bitmap2 = (0..2).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -26,8 +26,8 @@ fn no_symmetric_difference() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..8000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
     let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(2000..8000));
 
     bitmap1.symmetric_difference_with(&bitmap2);
@@ -37,8 +37,8 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap_to_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(6000..18000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
     let bitmap3 = RoaringBitmap::from_iter((0..6000).chain(12000..18000));
 
     bitmap1.symmetric_difference_with(&bitmap2);
@@ -48,8 +48,8 @@ fn bitmap_to_bitmap() {
 
 #[test]
 fn bitmap_to_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..6000);
-    let bitmap2 = RoaringBitmap::from_iter(2000..7000);
+    let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
+    let bitmap2 = (2000..7000).collect::<RoaringBitmap>();
     let bitmap3 = RoaringBitmap::from_iter((0..2000).chain(6000..7000));
 
     bitmap1.symmetric_difference_with(&bitmap2);
@@ -59,8 +59,8 @@ fn bitmap_to_array() {
 
 #[test]
 fn bitmap_and_array_to_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(11000..14000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (11000..14000).collect::<RoaringBitmap>();
     let bitmap3 = RoaringBitmap::from_iter((0..11000).chain(12000..14000));
 
     bitmap1.symmetric_difference_with(&bitmap2);
@@ -70,8 +70,8 @@ fn bitmap_and_array_to_bitmap() {
 
 #[test]
 fn bitmap_and_array_to_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..6000);
-    let bitmap2 = RoaringBitmap::from_iter(3000..7000);
+    let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
+    let bitmap2 = (3000..7000).collect::<RoaringBitmap>();
     let bitmap3 = RoaringBitmap::from_iter((0..3000).chain(6000..7000));
 
     bitmap1.symmetric_difference_with(&bitmap2);

--- a/tests/union_with.rs
+++ b/tests/union_with.rs
@@ -5,9 +5,9 @@ use std::iter::FromIterator;
 
 #[test]
 fn array_to_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..3000);
-    let bitmap3 = RoaringBitmap::from_iter(0..3000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..3000).collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 
@@ -16,9 +16,9 @@ fn array_to_array() {
 
 #[test]
 fn array_to_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..4000);
-    let bitmap2 = RoaringBitmap::from_iter(4000..8000);
-    let bitmap3 = RoaringBitmap::from_iter(0..8000);
+    let mut bitmap1 = (0..4000).collect::<RoaringBitmap>();
+    let bitmap2 = (4000..8000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..8000).collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 
@@ -27,9 +27,9 @@ fn array_to_bitmap() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..2000);
-    let bitmap2 = RoaringBitmap::from_iter(1000..8000);
-    let bitmap3 = RoaringBitmap::from_iter(0..8000);
+    let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
+    let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..8000).collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 
@@ -38,9 +38,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(6000..18000);
-    let bitmap3 = RoaringBitmap::from_iter(0..18000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..18000).collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 
@@ -49,9 +49,9 @@ fn bitmap() {
 
 #[test]
 fn bitmap_and_array() {
-    let mut bitmap1 = RoaringBitmap::from_iter(0..12000);
-    let bitmap2 = RoaringBitmap::from_iter(10000..13000);
-    let bitmap3 = RoaringBitmap::from_iter(0..13000);
+    let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
+    let bitmap2 = (10000..13000).collect::<RoaringBitmap>();
+    let bitmap3 = (0..13000).collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 


### PR DESCRIPTION
Change all calls to from_iter() into calls to collect().

It was only test code so no worries! Quick bit of regex (sometimes) saves the day 👍 

Closes #77.