### PR TITLE
refactor: fix all clippy-on-beta lints

### DIFF
--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -135,7 +135,7 @@ impl RoaringTreemap {
     /// use roaring::RoaringTreemap;
     /// use std::iter::FromIterator;
     ///
-    /// let bitmap = RoaringTreemap::from_iter(1..3);
+    /// let bitmap = (1..3).collect::<RoaringBitmap>();
     /// let mut iter = bitmap.iter();
     ///
     /// assert_eq!(iter.next(), Some(1));
@@ -155,7 +155,7 @@ impl RoaringTreemap {
     /// use roaring::{RoaringBitmap, RoaringTreemap};
     /// use std::iter::FromIterator;
     ///
-    /// let original = RoaringTreemap::from_iter(0..6000);
+    /// let original = (0..6000).collect::<RoaringBitmap>();
     /// let mut bitmaps = original.bitmaps();
     ///
     /// assert_eq!(bitmaps.next(), Some((0, &(0..6000).collect::<RoaringBitmap>())));
@@ -175,7 +175,7 @@ impl RoaringTreemap {
     /// use roaring::RoaringTreemap;
     /// use std::iter::FromIterator;
     ///
-    /// let original = RoaringTreemap::from_iter(0..6000);
+    /// let original = (0..6000).collect::<RoaringBitmap>();
     /// let clone = RoaringTreemap::from_bitmaps(original.bitmaps().map(|(p, b)| (p, b.clone())));
     ///
     /// assert_eq!(clone, original);

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -135,7 +135,7 @@ impl RoaringTreemap {
     /// use roaring::RoaringTreemap;
     /// use std::iter::FromIterator;
     ///
-    /// let bitmap = (1..3).collect::<RoaringBitmap>();
+    /// let bitmap = (1..3).collect::<RoaringTreemap>();
     /// let mut iter = bitmap.iter();
     ///
     /// assert_eq!(iter.next(), Some(1));
@@ -155,7 +155,7 @@ impl RoaringTreemap {
     /// use roaring::{RoaringBitmap, RoaringTreemap};
     /// use std::iter::FromIterator;
     ///
-    /// let original = (0..6000).collect::<RoaringBitmap>();
+    /// let original = (0..6000).collect::<RoaringTreemap>();
     /// let mut bitmaps = original.bitmaps();
     ///
     /// assert_eq!(bitmaps.next(), Some((0, &(0..6000).collect::<RoaringBitmap>())));
@@ -175,7 +175,7 @@ impl RoaringTreemap {
     /// use roaring::RoaringTreemap;
     /// use std::iter::FromIterator;
     ///
-    /// let original = (0..6000).collect::<RoaringBitmap>();
+    /// let original = (0..6000).collect::<RoaringTreemap>();
     /// let clone = RoaringTreemap::from_bitmaps(original.bitmaps().map(|(p, b)| (p, b.clone())));
     ///
     /// assert_eq!(clone, original);

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
     let original = (0..2000).collect::<RoaringBitmap>();
@@ -21,11 +19,10 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
+    let original = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -33,11 +30,10 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let original = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);

--- a/tests/difference_with.rs
+++ b/tests/difference_with.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
     let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
@@ -81,17 +79,17 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(1_000_000..1_001_000));
+    let mut bitmap1 = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (0..1000)
+        .chain(1_000_000..1_001_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -100,17 +98,15 @@ fn arrays() {
 
 #[test]
 fn arrays_removing_one_whole_container() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (0..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter(1_000_000..1_001_000);
+    let mut bitmap1 = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (0..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (1_000_000..1_001_000).collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 
@@ -119,17 +115,17 @@ fn arrays_removing_one_whole_container() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (3000..9000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter((0..3000).chain(1_000_000..1_006_000));
+    let mut bitmap1 = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (3000..9000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (0..3000)
+        .chain(1_000_000..1_006_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.difference_with(&bitmap2);
 

--- a/tests/intersect_with.rs
+++ b/tests/intersect_with.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
     let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
@@ -70,17 +68,17 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(3_000_000..3_001_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter((1000..2000).chain(1_001_000..1_002_000));
+    let mut bitmap1 = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(3_000_000..3_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (1000..2000)
+        .chain(1_001_000..1_002_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 
@@ -89,17 +87,17 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(3_000_000..3_010_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (3000..9000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter((3000..6000).chain(1_006_000..1_012_000));
+    let mut bitmap1 = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(3_000_000..3_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (3000..9000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (3000..6000)
+        .chain(1_006_000..1_012_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.intersect_with(&bitmap2);
 

--- a/tests/is_disjoint.rs
+++ b/tests/is_disjoint.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
     let bitmap1 = (0..2000).collect::<RoaringBitmap>();
@@ -33,44 +31,48 @@ fn bitmap_not() {
 
 #[test]
 fn arrays() {
-    let bitmap1 = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_002_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter((100_000..102_000).chain(1_100_000..1_102_000));
+    let bitmap1 = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_002_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (100_000..102_000)
+        .chain(1_100_000..1_102_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn arrays_not() {
-    let bitmap1 = RoaringBitmap::from_iter(
-        (0..2_000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_002_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter((100_000..102_000).chain(1_001_000..1_003_000));
+    let bitmap1 = (0..2_000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_002_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (100_000..102_000)
+        .chain(1_001_000..1_003_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }
 
 #[test]
 fn bitmaps() {
-    let bitmap1 = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_006_000)
-            .chain(2_000_000..2_006_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
+    let bitmap1 = (0..6000)
+        .chain(1_000_000..1_006_000)
+        .chain(2_000_000..2_006_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (100_000..106_000)
+        .chain(1_100_000..1_106_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn bitmaps_not() {
-    let bitmap1 = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_006_000)
-            .chain(2_000_000..2_006_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter((100_000..106_000).chain(1_004_000..1_008_000));
+    let bitmap1 = (0..6000)
+        .chain(1_000_000..1_006_000)
+        .chain(2_000_000..2_006_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (100_000..106_000)
+        .chain(1_004_000..1_008_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }

--- a/tests/is_subset.rs
+++ b/tests/is_subset.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array_not() {
     let sup = (0..2000).collect::<RoaringBitmap>();
@@ -54,32 +52,41 @@ fn bitmap_array() {
 
 #[test]
 fn arrays_not() {
-    let sup = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000));
-    let sub = RoaringBitmap::from_iter((100_000..102_000).chain(1_100_000..1_102_000));
+    let sup = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .collect::<RoaringBitmap>();
+    let sub = (100_000..102_000)
+        .chain(1_100_000..1_102_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), false);
 }
 
 #[test]
 fn arrays() {
-    let sup = RoaringBitmap::from_iter((0..3000).chain(100_000..103_000));
-    let sub = RoaringBitmap::from_iter((0..2000).chain(100_000..102_000));
+    let sup = (0..3000).chain(100_000..103_000).collect::<RoaringBitmap>();
+    let sub = (0..2000).chain(100_000..102_000).collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), true);
 }
 
 #[test]
 fn bitmaps_not() {
-    let sup = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_006_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let sub = RoaringBitmap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
+    let sup = (0..6000)
+        .chain(1_000_000..1_006_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let sub = (100_000..106_000)
+        .chain(1_100_000..1_106_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), false);
 }
 
 #[test]
 fn bitmaps() {
-    let sup = RoaringBitmap::from_iter((0..1_000_000).chain(2_000_000..2_010_000));
-    let sub = RoaringBitmap::from_iter((0..10_000).chain(500_000..510_000));
+    let sup = (0..1_000_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let sub = (0..10_000)
+        .chain(500_000..510_000)
+        .collect::<RoaringBitmap>();
     assert_eq!(sub.is_subset(&sup), true);
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -25,11 +25,10 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
+    let original = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
     let clone = RoaringBitmap::from_iter(&original);
     let clone2 = RoaringBitmap::from_iter(original.clone());
 
@@ -39,11 +38,10 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let original = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
     let clone = RoaringBitmap::from_iter(&original);
     let clone2 = RoaringBitmap::from_iter(original.clone());
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn smoke() {
     let mut bitmap = RoaringBitmap::new();
@@ -53,12 +51,12 @@ fn remove_range() {
     ];
     for (i, &a) in ranges.iter().enumerate() {
         for &b in &ranges[i..] {
-            let mut bitmap = RoaringBitmap::from_iter(0..=65536);
+            let mut bitmap = (0..=65536).collect::<RoaringBitmap>();
             assert_eq!(
                 bitmap.remove_range(u64::from(a)..u64::from(b)),
                 u64::from(b - a)
             );
-            assert_eq!(bitmap, RoaringBitmap::from_iter((0..a).chain(b..=65536)));
+            assert_eq!(bitmap, (0..a).chain(b..=65536).collect::<RoaringBitmap>());
         }
     }
 }
@@ -74,7 +72,7 @@ fn remove_range_array() {
 
     // insert 0, 2, 4, ..
     // remove [0, 2), [2, 4), ..
-    let mut bitmap = RoaringBitmap::from_iter((0..1000).map(|x| x * 2));
+    let mut bitmap = (0..1000).map(|x| x * 2).collect::<RoaringBitmap>();
     for i in 0..1000 {
         assert_eq!(bitmap.remove_range(i * 2..(i + 1) * 2), 1);
     }
@@ -89,7 +87,7 @@ fn remove_range_array() {
 #[test]
 #[allow(clippy::range_plus_one)] // remove_range needs an exclusive range
 fn remove_range_bitmap() {
-    let mut bitmap = RoaringBitmap::from_iter(0..4096 + 1000);
+    let mut bitmap = (0..4096 + 1000).collect::<RoaringBitmap>();
     for i in 0..1000 {
         assert_eq!(bitmap.remove_range(i..i), 0);
         assert_eq!(bitmap.remove_range(i..i + 1), 1);
@@ -97,19 +95,19 @@ fn remove_range_bitmap() {
 
     // insert 0, 2, 4, ..
     // remove [0, 2), [2, 4), ..
-    let mut bitmap = RoaringBitmap::from_iter((0..4096 + 1000).map(|x| x * 2));
+    let mut bitmap = ((0..4096 + 1000).map(|x| x * 2)).collect::<RoaringBitmap>();
     for i in 0..1000 {
         assert_eq!(bitmap.remove_range(i * 2..(i + 1) * 2), 1);
     }
 
     // remove [0, 2), [2, 4), ..
-    let mut bitmap = RoaringBitmap::from_iter(0..4096 + 1000);
+    let mut bitmap = (0..4096 + 1000).collect::<RoaringBitmap>();
     for i in 0..1000 / 2 {
         assert_eq!(bitmap.remove_range(i * 2..(i + 1) * 2), 2);
     }
 
     // remove [1, 3), [3, 5), ..
-    let mut bitmap = RoaringBitmap::from_iter(0..4096 + 1000);
+    let mut bitmap = (0..4096 + 1000).collect::<RoaringBitmap>();
     for i in 0..1000 / 2 {
         assert_eq!(bitmap.remove_range(i * 2 + 1..(i + 1) * 2 + 1), 2);
     }

--- a/tests/ops.rs
+++ b/tests/ops.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn or() {
     let mut rb1 = (1..4).collect::<RoaringBitmap>();
@@ -58,7 +56,7 @@ fn sub() {
 fn xor() {
     let mut rb1 = (1..4).collect::<RoaringBitmap>();
     let rb2 = (3..6).collect::<RoaringBitmap>();
-    let rb3 = RoaringBitmap::from_iter((1..3).chain(4..6));
+    let rb3 = (1..3).chain(4..6).collect::<RoaringBitmap>();
     let rb4 = (0..0).collect::<RoaringBitmap>();
 
     assert_eq!(rb3, &rb1 ^ &rb2);

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -1,19 +1,16 @@
 extern crate roaring;
 
-use std::iter::FromIterator;
-
 use roaring::RoaringBitmap;
 
 // Test data from https://github.com/RoaringBitmap/RoaringFormatSpec/tree/master/testdata
 static BITMAP_WITHOUT_RUNS: &[u8] = include_bytes!("bitmapwithoutruns.bin");
 
 fn test_data_bitmap() -> RoaringBitmap {
-    RoaringBitmap::from_iter(
-        (0..100)
-            .map(|i| i * 1000)
-            .chain((100_000..200_000).map(|i| i * 3))
-            .chain(700_000..800_000),
-    )
+    (0..100)
+        .map(|i| i * 1000)
+        .chain((100_000..200_000).map(|i| i * 3))
+        .chain(700_000..800_000)
+        .collect::<RoaringBitmap>()
 }
 
 fn serialize_and_deserialize(bitmap: &RoaringBitmap) -> RoaringBitmap {
@@ -99,21 +96,21 @@ fn test_bitmap() {
 
 #[test]
 fn test_arrays() {
-    let original = RoaringBitmap::from_iter((1000..3000).chain(70000..74000));
+    let original = (1000..3000).chain(70000..74000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
 
 #[test]
 fn test_bitmaps() {
-    let original = RoaringBitmap::from_iter((1000..6000).chain(70000..77000));
+    let original = (1000..6000).chain(70000..77000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
 
 #[test]
 fn test_mixed() {
-    let original = RoaringBitmap::from_iter((1000..3000).chain(70000..77000));
+    let original = (1000..3000).chain(70000..77000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
@@ -532,7 +529,7 @@ fn test_strange() {
         6684416, 6684424, 6684472, 6684563, 6684574, 6684575, 6684576, 6684577, 6684601, 6684635,
         6684636, 6684639, 6684640, 6684641, 6684642, 6684666, 108658947,
     ];
-    let original = RoaringBitmap::from_iter(ARRAY.iter().cloned());
+    let original = ARRAY.iter().cloned().collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }

--- a/tests/size_hint.rs
+++ b/tests/size_hint.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
     let bitmap = (0..2000).collect::<RoaringBitmap>();
@@ -27,11 +25,10 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let bitmap = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
+    let bitmap = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
     let mut iter = bitmap.iter();
     assert_eq!((5000, Some(5000)), iter.size_hint());
     iter.by_ref().take(3000).for_each(drop);
@@ -42,11 +39,10 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let bitmap = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let bitmap = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
     let mut iter = bitmap.iter();
     assert_eq!((28000, Some(28000)), iter.size_hint());
     iter.by_ref().take(2000).for_each(drop);

--- a/tests/symmetric_difference_with.rs
+++ b/tests/symmetric_difference_with.rs
@@ -1,13 +1,11 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
     let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
     let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
-    let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(2000..3000));
+    let bitmap3 = (0..1000).chain(2000..3000).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -28,7 +26,7 @@ fn no_symmetric_difference() {
 fn array_and_bitmap() {
     let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
     let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
-    let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(2000..8000));
+    let bitmap3 = (0..1000).chain(2000..8000).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -39,7 +37,7 @@ fn array_and_bitmap() {
 fn bitmap_to_bitmap() {
     let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
     let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
-    let bitmap3 = RoaringBitmap::from_iter((0..6000).chain(12000..18000));
+    let bitmap3 = (0..6000).chain(12000..18000).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -50,7 +48,7 @@ fn bitmap_to_bitmap() {
 fn bitmap_to_array() {
     let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
     let bitmap2 = (2000..7000).collect::<RoaringBitmap>();
-    let bitmap3 = RoaringBitmap::from_iter((0..2000).chain(6000..7000));
+    let bitmap3 = (0..2000).chain(6000..7000).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -61,7 +59,7 @@ fn bitmap_to_array() {
 fn bitmap_and_array_to_bitmap() {
     let mut bitmap1 = (0..12000).collect::<RoaringBitmap>();
     let bitmap2 = (11000..14000).collect::<RoaringBitmap>();
-    let bitmap3 = RoaringBitmap::from_iter((0..11000).chain(12000..14000));
+    let bitmap3 = (0..11000).chain(12000..14000).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -72,7 +70,7 @@ fn bitmap_and_array_to_bitmap() {
 fn bitmap_and_array_to_array() {
     let mut bitmap1 = (0..6000).collect::<RoaringBitmap>();
     let bitmap2 = (3000..7000).collect::<RoaringBitmap>();
-    let bitmap3 = RoaringBitmap::from_iter((0..3000).chain(6000..7000));
+    let bitmap3 = (0..3000).chain(6000..7000).collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -81,24 +79,21 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(3_000_000..3_001_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_000_001),
-    );
-    let bitmap3 = RoaringBitmap::from_iter(
-        (0..1000)
-            .chain(1_000_000..1_001_000)
-            .chain(2000..3000)
-            .chain(1_002_000..1_003_000)
-            .chain(2_000_000..2_000_001)
-            .chain(3_000_000..3_001_000),
-    );
+    let mut bitmap1 = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(3_000_000..3_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_000_001)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (0..1000)
+        .chain(1_000_000..1_001_000)
+        .chain(2000..3000)
+        .chain(1_002_000..1_003_000)
+        .chain(2_000_000..2_000_001)
+        .chain(3_000_000..3_001_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -107,24 +102,21 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(3_000_000..3_010_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (3000..7000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter(
-        (0..3000)
-            .chain(1_000_000..1_006_000)
-            .chain(6000..7000)
-            .chain(1_012_000..1_018_000)
-            .chain(2_000_000..2_010_000)
-            .chain(3_000_000..3_010_000),
-    );
+    let mut bitmap1 = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(3_000_000..3_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (3000..7000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (0..3000)
+        .chain(1_000_000..1_006_000)
+        .chain(6000..7000)
+        .chain(1_012_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .chain(3_000_000..3_010_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.symmetric_difference_with(&bitmap2);
 

--- a/tests/union_with.rs
+++ b/tests/union_with.rs
@@ -1,8 +1,6 @@
 extern crate roaring;
 use roaring::RoaringBitmap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array_to_array() {
     let mut bitmap1 = (0..2000).collect::<RoaringBitmap>();
@@ -60,22 +58,19 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(3_000_000..3_001_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter(
-        (0..3000)
-            .chain(1_000_000..1_003_000)
-            .chain(2_000_000..2_001_000)
-            .chain(3_000_000..3_001_000),
-    );
+    let mut bitmap1 = (0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(3_000_000..3_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (0..3000)
+        .chain(1_000_000..1_003_000)
+        .chain(2_000_000..2_001_000)
+        .chain(3_000_000..3_001_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 
@@ -84,22 +79,19 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(3_000_000..3_010_000),
-    );
-    let bitmap2 = RoaringBitmap::from_iter(
-        (3000..9000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringBitmap::from_iter(
-        (0..9000)
-            .chain(1_000_000..1_018_000)
-            .chain(2_000_000..2_010_000)
-            .chain(3_000_000..3_010_000),
-    );
+    let mut bitmap1 = (0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(3_000_000..3_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap2 = (3000..9000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .collect::<RoaringBitmap>();
+    let bitmap3 = (0..9000)
+        .chain(1_000_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .chain(3_000_000..3_010_000)
+        .collect::<RoaringBitmap>();
 
     bitmap1.union_with(&bitmap2);
 


### PR DESCRIPTION
So despite #78 passing CI and being merged, the PR for #76 failed on
**more** `from_iter()` that were not a problem before!

This PR fixes all the lints shown when running:

	cargo +beta clippy --all-targets -- -D warnings

@Kerollmops I hope this resolves our fun journey!