### PR TITLE
Improve the RoaringBitmap deserialize_from method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "Nemo157/roaring-rs" }
 
 [dependencies]
+bytemuck = "1.5.1"
 byteorder = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Reading the exact amount of bytes into the final `Vec` and then applying the endianness changes afterward gives better performances. The endianness loop is totally evicted when the platform endianness is already in little endian. To write the bytes from the reader directly into [the byte representation of the final `Vec`](https://docs.rs/bytemuck/1.5.1/bytemuck/fn.try_cast_slice_mut.html) I introduce the  `bytemuck` crate.