### PR TITLE
Improve unions between arrays

### DIFF
--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -296,17 +296,19 @@ impl Store {
                     let mut i = 0;
                     let mut j = 0;
                     while i < arr1.len() && j < arr2.len() {
-                        match arr1[i].cmp(&arr2[j]) {
+                        let a = unsafe { arr1.get_unchecked(i) };
+                        let b = unsafe { arr2.get_unchecked(j) };
+                        match a.cmp(&b) {
                             Less => {
-                                out.push(arr1[i]);
+                                out.push(*a);
                                 i += 1
                             }
                             Greater => {
-                                out.push(arr2[j]);
+                                out.push(*b);
                                 j += 1
                             }
                             Equal => {
-                                out.push(arr1[i]);
+                                out.push(*a);
                                 i += 1;
                                 j += 1;
                             }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -289,7 +289,8 @@ impl Store {
         match (self, other) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {
                 fn merge_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
-                    let mut out = Vec::with_capacity(arr1.len().max(arr2.len()));
+                    let len = (arr1.len() + arr2.len()).min(4096);
+                    let mut out = Vec::with_capacity(len);
 
                     // Traverse both arrays
                     let mut i = 0;


### PR DESCRIPTION
I found out that merging two arrays was quite slow while benchmarking our new search engine. Doing unions of array containers needed improvement. I reworked the algorithm to make it easier to read and removed the inserts triggering a lot of useless memory copy, and made it write into a new allocation.

I found out that CRoaring (which is the roaring implementation in c) [was doing a lot SIMD based things to do fast array unions](https://github.com/RoaringBitmap/CRoaring/blob/63a54b15df3bc8fad77a9cc26fbc2dcce5f8da23/src/array_util.c#L1894-L1915), I did not implement them because it would take me a lot of time and that I would prefer using the, soon to be released, [stdsimd library](https://github.com/rust-lang/stdsimd).