### PR TITLE
Use the retain_mut external library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "Nemo157/roaring-rs" }
 [dependencies]
 bytemuck = "1.5.1"
 byteorder = "1.0"
+retain_mut = "0.1.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -1,6 +1,7 @@
+use retain_mut::RetainMut;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
-use crate::{retain_mut, RoaringBitmap};
+use crate::RoaringBitmap;
 
 impl RoaringBitmap {
     /// Unions in-place with the specified other bitmap.
@@ -72,7 +73,7 @@ impl RoaringBitmap {
     /// assert_eq!(rb1, rb3);
     /// ```
     pub fn intersect_with(&mut self, other: &RoaringBitmap) {
-        retain_mut(&mut self.containers, |cont| {
+        self.containers.retain_mut(|cont| {
             match other.containers.binary_search_by_key(&cont.key, |c| c.key) {
                 Ok(loc) => {
                     cont.intersect_with(&other.containers[loc]);
@@ -113,7 +114,7 @@ impl RoaringBitmap {
     /// assert_eq!(rb1, rb3);
     /// ```
     pub fn difference_with(&mut self, other: &RoaringBitmap) {
-        retain_mut(&mut self.containers, |cont| {
+        self.containers.retain_mut(|cont| {
             match other.containers.binary_search_by_key(&cont.key, |c| c.key) {
                 Ok(loc) => {
                     cont.difference_with(&other.containers[loc]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,25 +21,3 @@ pub mod treemap;
 
 pub use bitmap::RoaringBitmap;
 pub use treemap::RoaringTreemap;
-
-fn retain_mut<T, F>(vec: &mut Vec<T>, mut f: F)
-where
-    F: FnMut(&mut T) -> bool,
-{
-    let len = vec.len();
-    let mut del = 0;
-    {
-        let v = &mut **vec;
-
-        for i in 0..len {
-            if !f(&mut v[i]) {
-                del += 1;
-            } else if del > 0 {
-                v.swap(i - del, i);
-            }
-        }
-    }
-    if del > 0 {
-        vec.truncate(len - del);
-    }
-}


### PR DESCRIPTION
Related to #87 but do not fix it yet.

Thanks to @upsuper and its [retain_mut library](https://docs.rs/retain_mut), we can remove our internal copy of the [std `retain` function](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.retain) and let it be maintained externally (until `retain_mut` is merged into the std).