### PR TITLE
Rework the insert/remove_range functions with RangeBounds

### DIFF
--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -223,7 +223,7 @@ fn remove_range_bitmap(c: &mut Criterion) {
 fn insert_range_bitmap(c: &mut Criterion) {
     for &size in &[10, 100, 1_000, 5_000, 10_000, 20_000] {
         let mut group = c.benchmark_group("insert_range");
-        group.throughput(criterion::Throughput::Elements(size));
+        group.throughput(criterion::Throughput::Elements(size as u64));
         group.bench_function(format!("from_empty_{}", size), |b| {
             let bm = RoaringBitmap::new();
             b.iter_batched(

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,5 +1,7 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
-use std::{fmt, ops::Range};
+use std::fmt;
+use std::ops::{
+    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,
+};
 
 use super::store::{self, Store};
 use super::util;
@@ -35,13 +37,7 @@ impl Container {
         }
     }
 
-    pub fn insert_range(&mut self, range: Range<u16>) -> u64 {
-        // If the range is larger than the array limit, skip populating the
-        // array to then have to convert it to a bitmap anyway.
-        if matches!(self.store, Store::Array(_)) && range.end - range.start > ARRAY_LIMIT as u16 {
-            self.store = self.store.to_bitmap()
-        }
-
+    pub fn insert_range(&mut self, range: RangeInclusive<u16>) -> u64 {
         let inserted = self.store.insert_range(range);
         self.len += inserted;
         self.ensure_correct_store();
@@ -71,12 +67,8 @@ impl Container {
         }
     }
 
-    pub fn remove_range(&mut self, start: u32, end: u32) -> u64 {
-        debug_assert!(start <= end);
-        if start == end {
-            return 0;
-        }
-        let result = self.store.remove_range(start, end);
+    pub fn remove_range(&mut self, range: RangeInclusive<u16>) -> u64 {
+        let result = self.store.remove_range(range);
         self.len -= result;
         self.ensure_correct_store();
         result

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -1,8 +1,9 @@
+use std::ops::{Bound, RangeBounds};
+
 use crate::RoaringBitmap;
 
 use super::container::Container;
 use super::util;
-use std::ops::Range;
 
 impl RoaringBitmap {
     /// Creates an empty `RoaringBitmap`.
@@ -43,15 +44,8 @@ impl RoaringBitmap {
         container.insert(index)
     }
 
-    /// Inserts a range of values from the set specific as [start..end). Returns
-    /// the number of inserted values.
-    ///
-    /// Note that due to the exclusive end this functions take indexes as u64
-    /// but you still can't index past 2**32 (u32::MAX + 1).
-    ///
-    /// # Safety
-    ///
-    /// This function panics if the range upper bound exceeds `u32::MAX`.
+    /// Inserts a range of values from the set.
+    /// Returns the number of inserted values.
     ///
     /// # Examples
     ///
@@ -64,14 +58,31 @@ impl RoaringBitmap {
     /// assert!(rb.contains(3));
     /// assert!(!rb.contains(4));
     /// ```
-    pub fn insert_range(&mut self, range: Range<u64>) -> u64 {
-        assert!(range.end <= u64::from(u32::max_value()) + 1, "can't index past 2**32");
-        if range.is_empty() {
+    pub fn insert_range<R: RangeBounds<u32>>(&mut self, range: R) -> u64 {
+        let start = match range.start_bound() {
+            Bound::Included(value) => *value,
+            Bound::Excluded(value) => match value.checked_add(1) {
+                Some(value) => value,
+                None => return 0,
+            },
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(value) => match value.checked_add(1) {
+                Some(value) => value,
+                None => return 0,
+            },
+            Bound::Excluded(value) => *value,
+            Bound::Unbounded => u32::max_value(),
+        };
+
+        if end.saturating_sub(start) == 0 {
             return 0;
         }
 
-        let (start_container_key, start_index) = util::split(range.start as u32);
-        let (end_container_key, end_index) = util::split((range.end) as u32);
+        let (start_container_key, start_index) = util::split(start);
+        let (end_container_key, end_index) = util::split(end);
 
         // Find the container index for start_container_key
         let start_i = match self.containers.binary_search_by_key(&start_container_key, |c| c.key) {
@@ -122,7 +133,7 @@ impl RoaringBitmap {
         let c = match self.containers.get_mut(end_i) {
             Some(c) => c,
             None => {
-                let (key, _) = util::split(range.start as u32);
+                let (key, _) = util::split(start);
                 self.containers.insert(end_i, Container::new(key));
                 &mut self.containers[end_i]
             }
@@ -193,11 +204,9 @@ impl RoaringBitmap {
             _ => false,
         }
     }
-    /// Removes a range of values from the set specific as [start..end).
+
+    /// Removes a range of values from the set.
     /// Returns the number of removed values.
-    ///
-    /// Note that due to the exclusive end this functions take indexes as u64
-    /// but you still can't index past 2**32 (u32::MAX + 1).
     ///
     /// # Examples
     ///
@@ -209,14 +218,31 @@ impl RoaringBitmap {
     /// rb.insert(3);
     /// assert_eq!(rb.remove_range(2..4), 2);
     /// ```
-    pub fn remove_range(&mut self, range: Range<u64>) -> u64 {
-        assert!(range.end <= u64::from(u32::max_value()) + 1, "can't index past 2**32");
-        if range.is_empty() {
+    pub fn remove_range<R: RangeBounds<u32>>(&mut self, range: R) -> u64 {
+        let start = match range.start_bound() {
+            Bound::Included(value) => *value,
+            Bound::Excluded(value) => match value.checked_add(1) {
+                Some(value) => value,
+                None => return 0,
+            },
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(value) => match value.checked_add(1) {
+                Some(value) => value,
+                None => return 0,
+            },
+            Bound::Excluded(value) => *value,
+            Bound::Unbounded => u32::max_value(),
+        };
+
+        if end.saturating_sub(start) == 0 {
             return 0;
         }
         // inclusive bounds for start and end
-        let (start_hi, start_lo) = util::split(range.start as u32);
-        let (end_hi, end_lo) = util::split((range.end - 1) as u32);
+        let (start_hi, start_lo) = util::split(start);
+        let (end_hi, end_lo) = util::split(end - 1);
         let mut index = 0;
         let mut result = 0;
         while index < self.containers.len() {
@@ -377,19 +403,20 @@ impl Clone for RoaringBitmap {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::ops::Range;
+
     use quickcheck_macros::quickcheck;
+
+    use super::*;
 
     #[quickcheck]
     fn insert_range(r: Range<u32>, checks: Vec<u32>) {
-        let r: Range<u64> = u64::from(r.start)..u64::from(r.end);
-
         let mut b = RoaringBitmap::new();
         let inserted = b.insert_range(r.clone());
         if r.end > r.start {
-            assert_eq!(inserted, r.end - r.start);
+            assert_eq!(inserted as u32, r.end - r.start);
         } else {
-            assert_eq!(inserted, 0);
+            assert_eq!(inserted as u32, 0);
         }
 
         // Assert all values in the range are present
@@ -400,7 +427,7 @@ mod tests {
         // Run the check values looking for any false positives
         for i in checks {
             let bitmap_has = b.contains(i);
-            let range_has = r.contains(&u64::from(i));
+            let range_has = r.contains(&i);
             assert!(
                 bitmap_has == range_has,
                 "value {} in bitmap={} and range={}",

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -76,13 +76,10 @@ impl RoaringBitmap {
     where
         R: RangeBounds<u32>,
     {
-        let (start, end);
-        if let Some(range) = util::convert_range_to_inclusive(range) {
-            start = *range.start();
-            end = *range.end();
-        } else {
-            return 0;
-        }
+        let (start, end) = match util::convert_range_to_inclusive(range) {
+            Some(range) => (*range.start(), *range.end()),
+            None => return 0,
+        };
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -470,4 +470,41 @@ mod tests {
 
         assert_eq!(b.containers.len(), 0);
     }
+
+    #[test]
+    fn test_insert_remove_range_multi_container() {
+        let mut bitmap = RoaringBitmap::new();
+        assert_eq!(
+            bitmap.insert_range(0..((1_u32 << 16) + 1)),
+            (1_u64 << 16) + 1
+        );
+        assert_eq!(bitmap.containers.len(), 2);
+        assert_eq!(bitmap.containers[0].key, 0);
+        assert_eq!(bitmap.containers[1].key, 1);
+        assert_eq!(
+            bitmap.insert_range(0..((1_u32 << 16) + 1)),
+            0
+        );
+
+        assert!(bitmap.insert((1_u32 << 16) * 4));
+        assert_eq!(bitmap.containers.len(), 3);
+        assert_eq!(bitmap.containers[2].key, 4);
+
+        assert_eq!(
+            bitmap.remove_range(((1_u32 << 16) * 3)..=((1_u32 << 16) * 4)),
+            1
+        );
+        assert_eq!(bitmap.containers.len(), 2);
+    }
+
+    #[test]
+    fn insert_range_single() {
+        let mut bitmap = RoaringBitmap::new();
+        assert_eq!(
+            bitmap.insert_range((1_u32 << 16)..(2_u32 << 16)),
+            1_u64 << 16
+        );
+        assert_eq!(bitmap.containers.len(), 1);
+        assert_eq!(bitmap.containers[0].key, 1);
+    }
 }

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -201,13 +201,10 @@ impl RoaringBitmap {
     where
         R: RangeBounds<u32>,
     {
-        let (start, end);
-        if let Some(range) = util::convert_range_to_inclusive(range) {
-            start = *range.start();
-            end = *range.end();
-        } else {
-            return 0;
-        }
+        let (start, end) = match util::convert_range_to_inclusive(range) {
+            Some(range) => (*range.start(), *range.end()),
+            None => return 0,
+        };
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);
@@ -377,7 +374,6 @@ mod tests {
 
     #[quickcheck]
     fn qc_insert_range(r: Range<u32>, checks: Vec<u32>) {
-
         let mut b = RoaringBitmap::new();
         let inserted = b.insert_range(r.clone());
         if r.end > r.start {

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -214,16 +214,8 @@ impl RoaringBitmap {
         while index < self.containers.len() {
             let key = self.containers[index].key;
             if key >= start_container_key && key <= end_container_key {
-                let a = if key == start_container_key {
-                    start_index
-                } else {
-                    0
-                };
-                let b = if key == end_container_key {
-                    end_index
-                } else {
-                    u16::max_value()
-                };
+                let a = if key == start_container_key { start_index } else { 0 };
+                let b = if key == end_container_key { end_index } else { u16::MAX };
                 removed += self.containers[index].remove_range(a..=b);
                 if self.containers[index].len == 0 {
                     self.containers.remove(index);
@@ -470,10 +462,7 @@ mod tests {
     #[test]
     fn test_insert_remove_range_multi_container() {
         let mut bitmap = RoaringBitmap::new();
-        assert_eq!(
-            bitmap.insert_range(0..((1_u32 << 16) + 1)),
-            (1_u64 << 16) + 1
-        );
+        assert_eq!(bitmap.insert_range(0..((1_u32 << 16) + 1)), (1_u64 << 16) + 1);
         assert_eq!(bitmap.containers.len(), 2);
         assert_eq!(bitmap.containers[0].key, 0);
         assert_eq!(bitmap.containers[1].key, 1);
@@ -483,20 +472,14 @@ mod tests {
         assert_eq!(bitmap.containers.len(), 3);
         assert_eq!(bitmap.containers[2].key, 4);
 
-        assert_eq!(
-            bitmap.remove_range(((1_u32 << 16) * 3)..=((1_u32 << 16) * 4)),
-            1
-        );
+        assert_eq!(bitmap.remove_range(((1_u32 << 16) * 3)..=((1_u32 << 16) * 4)), 1);
         assert_eq!(bitmap.containers.len(), 2);
     }
 
     #[test]
     fn insert_range_single() {
         let mut bitmap = RoaringBitmap::new();
-        assert_eq!(
-            bitmap.insert_range((1_u32 << 16)..(2_u32 << 16)),
-            1_u64 << 16
-        );
+        assert_eq!(bitmap.insert_range((1_u32 << 16)..(2_u32 << 16)), 1_u64 << 16);
         assert_eq!(bitmap.containers.len(), 1);
         assert_eq!(bitmap.containers[0].key, 1);
     }

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -76,13 +76,13 @@ impl RoaringBitmap {
     where
         R: RangeBounds<u32>,
     {
-        let (range, is_empty) = util::convert_range_to_inclusive(range);
-        if is_empty {
+        let (start, end);
+        if let Some(range) = util::convert_range_to_inclusive(range) {
+            start = *range.start();
+            end = *range.end();
+        } else {
             return 0;
         }
-
-        let start = *range.start();
-        let end = *range.end();
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);
@@ -201,13 +201,13 @@ impl RoaringBitmap {
     where
         R: RangeBounds<u32>,
     {
-        let (range, is_empty) = util::convert_range_to_inclusive(range);
-        if is_empty {
+        let (start, end);
+        if let Some(range) = util::convert_range_to_inclusive(range) {
+            start = *range.start();
+            end = *range.end();
+        } else {
             return 0;
         }
-
-        let start = *range.start();
-        let end = *range.end();
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);
@@ -376,8 +376,7 @@ mod tests {
     use super::*;
 
     #[quickcheck]
-    fn insert_range(r: Range<u32>, checks: Vec<u32>) {
-        let r: Range<u32> = u32::from(r.start)..u32::from(r.end);
+    fn qc_insert_range(r: Range<u32>, checks: Vec<u32>) {
 
         let mut b = RoaringBitmap::new();
         let inserted = b.insert_range(r.clone());
@@ -436,10 +435,11 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_full() {
+    fn test_insert_max_u32() {
         let mut b = RoaringBitmap::new();
-        let inserted = b.insert_range(0..=u32::MAX);
-        assert_eq!(inserted, u32::MAX as u64 + 1);
+        let inserted = b.insert(u32::MAX);
+        // We are allowed to add u32::MAX
+        assert!(inserted);
     }
 
     #[test]
@@ -481,10 +481,7 @@ mod tests {
         assert_eq!(bitmap.containers.len(), 2);
         assert_eq!(bitmap.containers[0].key, 0);
         assert_eq!(bitmap.containers[1].key, 1);
-        assert_eq!(
-            bitmap.insert_range(0..((1_u32 << 16) + 1)),
-            0
-        );
+        assert_eq!(bitmap.insert_range(0..((1_u32 << 16) + 1)), 0);
 
         assert!(bitmap.insert((1_u32 << 16) * 4));
         assert_eq!(bitmap.containers.len(), 3);

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -50,10 +50,10 @@ impl<'a> Iterator for Iter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.size_hint < usize::max_value() as u64 {
+        if self.size_hint < usize::MAX as u64 {
             (self.size_hint as usize, Some(self.size_hint as usize))
         } else {
-            (usize::max_value(), None)
+            (usize::MAX, None)
         }
     }
 }
@@ -67,10 +67,10 @@ impl Iterator for IntoIter {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.size_hint < usize::max_value() as u64 {
+        if self.size_hint < usize::MAX as u64 {
             (self.size_hint as usize, Some(self.size_hint as usize))
         } else {
-            (usize::max_value(), None)
+            (usize::MAX, None)
         }
     }
 }

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -128,7 +128,7 @@ impl RoaringBitmap {
             }
         };
 
-        if size > u16::max_value() as usize + 1 {
+        if size > u16::MAX as usize + 1 {
             return Err(io::Error::new(io::ErrorKind::Other, "size is greater than supported"));
         }
 

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -180,7 +180,7 @@ impl Store {
                 let (end_key, end_bit) = (key(end), bit(end));
 
                 if start_key == end_key {
-                    let mask = (!0u64 << start_bit) & (!0u64 >> (63 - end_bit));
+                    let mask = (u64::MAX << start_bit) & (u64::MAX >> (63 - end_bit));
                     let removed = (bits[start_key] & mask).count_ones();
                     bits[start_key] &= !mask;
                     return u64::from(removed);
@@ -188,8 +188,8 @@ impl Store {
 
                 let mut removed = 0;
                 // start key bits
-                removed += (bits[start_key] & (!0u64 << start_bit)).count_ones();
-                bits[start_key] &= !(!0u64 << start_bit);
+                removed += (bits[start_key] & (u64::MAX << start_bit)).count_ones();
+                bits[start_key] &= !(u64::MAX << start_bit);
                 // counts bits in between
                 for word in &bits[start_key + 1..end_key] {
                     removed += word.count_ones();
@@ -202,8 +202,8 @@ impl Store {
                     *word = 0;
                 }
                 // end key bits
-                removed += (bits[end_key] & (!0u64 >> (63 - end_bit))).count_ones();
-                bits[end_key] &= !(!0u64 >> (63 - end_bit));
+                removed += (bits[end_key] & (u64::MAX >> (63 - end_bit))).count_ones();
+                bits[end_key] &= !(u64::MAX >> (63 - end_bit));
                 u64::from(removed)
             }
         }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -381,7 +381,7 @@ impl BitOrAssign<&Store> for Store {
         match (self, rhs) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {
                 let this = mem::take(vec1);
-                *vec1 = union_arrays(&this, &vec2);
+                *vec1 = union_arrays(&this, vec2);
             }
             (this @ &mut Bitmap(..), &Array(ref vec)) => {
                 vec.iter().for_each(|index| {
@@ -763,7 +763,7 @@ fn union_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
     while i < arr1.len() && j < arr2.len() {
         let a = unsafe { arr1.get_unchecked(i) };
         let b = unsafe { arr2.get_unchecked(j) };
-        match a.cmp(&b) {
+        match a.cmp(b) {
             Less => {
                 out.push(*a);
                 i += 1;
@@ -797,7 +797,7 @@ fn intersect_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
     while i < arr1.len() && j < arr2.len() {
         let a = unsafe { arr1.get_unchecked(i) };
         let b = unsafe { arr2.get_unchecked(j) };
-        match a.cmp(&b) {
+        match a.cmp(b) {
             Less => i += 1,
             Greater => j += 1,
             Equal => {
@@ -821,7 +821,7 @@ fn difference_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
     while i < arr1.len() && j < arr2.len() {
         let a = unsafe { arr1.get_unchecked(i) };
         let b = unsafe { arr2.get_unchecked(j) };
-        match a.cmp(&b) {
+        match a.cmp(b) {
             Less => {
                 out.push(*a);
                 i += 1;
@@ -850,7 +850,7 @@ fn symmetric_difference_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
     while i < arr1.len() && j < arr2.len() {
         let a = unsafe { arr1.get_unchecked(i) };
         let b = unsafe { arr2.get_unchecked(j) };
-        match a.cmp(&b) {
+        match a.cmp(b) {
             Less => {
                 out.push(*a);
                 i += 1;

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,11 +1,14 @@
-use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
-use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
+use std::borrow::Borrow;
+use std::cmp::Ordering::{Equal, Greater, Less};
+use std::ops::{
+    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,
+};
+
+use self::Store::{Array, Bitmap};
 
 const BITMAP_LENGTH: usize = 1024;
 
-use self::Store::{Array, Bitmap};
 pub enum Store {
     Array(Vec<u16>),
     Bitmap(Box<[u64; BITMAP_LENGTH]>),
@@ -42,40 +45,55 @@ impl Store {
         }
     }
 
-    pub fn insert_range(&mut self, range: Range<u16>) -> u64 {
+    pub fn insert_range(&mut self, range: RangeInclusive<u16>) -> u64 {
         // A Range is defined as being of size 0 if start >= end.
         if range.is_empty() {
             return 0;
         }
 
+        let start = *range.start();
+        let end = *range.end();
+
         match *self {
             Array(ref mut vec) => {
-                // Figure out the starting/ending position in the vec
-                let pos_start = vec.binary_search(&range.start).unwrap_or_else(|x| x);
-                let pos_end = vec.binary_search(&range.end).unwrap_or_else(|x| x);
+                // Figure out the starting/ending position in the vec.
+                let pos_start = vec.binary_search(&start).unwrap_or_else(|x| x);
+                let pos_end = vec
+                    .binary_search_by(|p| {
+                        // binary search the right most position when equals
+                        match p.cmp(&end) {
+                            Greater => Greater,
+                            _ => Less,
+                        }
+                    })
+                    .unwrap_or_else(|x| x);
 
                 // Overwrite the range in the middle - there's no need to take
                 // into account any existing elements between start and end, as
                 // they're all being added to the set.
-                let dropped = vec.splice(pos_start..pos_end, range.clone());
+                let dropped = vec.splice(pos_start..pos_end, start..=end);
 
-                u64::from(range.end - range.start) - dropped.len() as u64
+                end as u64 - start as u64 + 1 - dropped.len() as u64
             }
             Bitmap(ref mut bits) => {
-                let (start_key, start_bit) = (key(range.start), bit(range.start));
-                let (end_key, end_bit) = (key(range.end), bit(range.end));
+                let (start_key, start_bit) = (key(start), bit(start));
+                let (end_key, end_bit) = (key(end), bit(end));
 
+                // MSB > start_bit > end_bit > LSB
                 if start_key == end_key {
                     // Set the end_bit -> LSB to 1
-                    let mut mask = (1 << end_bit) - 1;
-                    // Set start_bit -> LSB to 0
+                    let mut mask = if end_bit == 63 {
+                        u64::MAX
+                    } else {
+                        (1 << (end_bit + 1)) - 1
+                    };
+                    // Set MSB -> start_bit to 1
                     mask &= !((1 << start_bit) - 1);
-                    // Leaving end_bit -> start_bit set to 1
 
                     let existed = (bits[start_key] & mask).count_ones();
                     bits[start_key] |= mask;
 
-                    return u64::from(range.end - range.start) - u64::from(existed);
+                    return u64::from(end - start + 1) - u64::from(existed);
                 }
 
                 // Mask off the left-most bits (MSB -> start_bit)
@@ -94,11 +112,15 @@ impl Store {
                 }
 
                 // Set the end bits in the last chunk (MSB -> end_bit)
-                let mask = (1 << end_bit) - 1;
+                let mask = if end_bit == 63 {
+                    u64::MAX
+                } else {
+                    (1 << (end_bit + 1)) - 1
+                };
                 existed += (bits[end_key] & mask).count_ones();
                 bits[end_key] |= mask;
 
-                u64::from(range.end - range.start) - u64::from(existed)
+                end as u64 - start as u64 + 1 - existed as u64
             }
         }
     }
@@ -136,28 +158,36 @@ impl Store {
         }
     }
 
-    pub fn remove_range(&mut self, start: u32, end: u32) -> u64 {
-        debug_assert!(start < end, "caller must ensure start < end");
+    pub fn remove_range(&mut self, range: RangeInclusive<u16>) -> u64 {
+        if range.is_empty() {
+            return 0;
+        }
+
+        let start = *range.start();
+        let end = *range.end();
+
         match *self {
             Array(ref mut vec) => {
-                let a = vec.binary_search(&(start as u16)).unwrap_or_else(|e| e);
-                let b = if end > u32::from(u16::max_value()) {
-                    vec.len()
-                } else {
-                    vec.binary_search(&(end as u16)).unwrap_or_else(|e| e)
-                };
-                vec.drain(a..b);
-                (b - a) as u64
+                // Figure out the starting/ending position in the vec.
+                let pos_start = vec.binary_search(&start).unwrap_or_else(|x| x);
+                let pos_end = vec
+                    .binary_search_by(|p| {
+                        // binary search the right most position when equals
+                        match p.cmp(&end) {
+                            Greater => Greater,
+                            _ => Less,
+                        }
+                    })
+                    .unwrap_or_else(|x| x);
+                vec.drain(pos_start..pos_end);
+                (pos_end - pos_start) as u64
             }
             Bitmap(ref mut bits) => {
-                let start_key = key(start as u16) as usize;
-                let start_bit = bit(start as u16) as u32;
-                // end_key is inclusive
-                let end_key = key((end - 1) as u16) as usize;
-                let end_bit = bit(end as u16) as u32;
+                let (start_key, start_bit) = (key(start), bit(start));
+                let (end_key, end_bit) = (key(end), bit(end));
 
                 if start_key == end_key {
-                    let mask = (!0u64 << start_bit) & (!0u64).wrapping_shr(64 - end_bit);
+                    let mask = (!0u64 << start_bit) & (!0u64 >> (63 - end_bit));
                     let removed = (bits[start_key] & mask).count_ones();
                     bits[start_key] &= !mask;
                     return u64::from(removed);
@@ -179,8 +209,8 @@ impl Store {
                     *word = 0;
                 }
                 // end key bits
-                removed += (bits[end_key] & (!0u64).wrapping_shr(64 - end_bit)).count_ones();
-                bits[end_key] &= !(!0u64).wrapping_shr(64 - end_bit);
+                removed += (bits[end_key] & (!0u64 >> (63 - end_bit))).count_ones();
+                bits[end_key] &= !(!0u64 >> (63 - end_bit));
                 u64::from(removed)
             }
         }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,9 +1,10 @@
-use std::{mem, slice, vec};
 use std::borrow::Borrow;
 use std::cmp::Ordering::{Equal, Greater, Less};
+use std::mem;
 use std::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,
 };
+use std::{slice, vec};
 
 use self::Store::{Array, Bitmap};
 
@@ -82,11 +83,7 @@ impl Store {
                 // MSB > start_bit > end_bit > LSB
                 if start_key == end_key {
                     // Set the end_bit -> LSB to 1
-                    let mut mask = if end_bit == 63 {
-                        u64::MAX
-                    } else {
-                        (1 << (end_bit + 1)) - 1
-                    };
+                    let mut mask = if end_bit == 63 { u64::MAX } else { (1 << (end_bit + 1)) - 1 };
                     // Set MSB -> start_bit to 1
                     mask &= !((1 << start_bit) - 1);
 
@@ -112,11 +109,7 @@ impl Store {
                 }
 
                 // Set the end bits in the last chunk (MSB -> end_bit)
-                let mask = if end_bit == 63 {
-                    u64::MAX
-                } else {
-                    (1 << (end_bit + 1)) - 1
-                };
+                let mask = if end_bit == 63 { u64::MAX } else { (1 << (end_bit + 1)) - 1 };
                 existed += (bits[end_key] & mask).count_ones();
                 bits[end_key] |= mask;
 
@@ -907,7 +900,7 @@ mod tests {
         let mut store = Store::Array(vec![1, 2, 8, 9]);
 
         // Insert a range with start > end.
-        let new = store.insert_range(6..1);
+        let new = store.insert_range(6..=1);
         assert_eq!(new, 0);
 
         assert_eq!(as_vec(store), vec![1, 2, 8, 9]);
@@ -917,7 +910,7 @@ mod tests {
     fn test_array_insert_range() {
         let mut store = Store::Array(vec![1, 2, 8, 9]);
 
-        let new = store.insert_range(4..6);
+        let new = store.insert_range(4..=5);
         assert_eq!(new, 2);
 
         assert_eq!(as_vec(store), vec![1, 2, 4, 5, 8, 9]);
@@ -927,7 +920,7 @@ mod tests {
     fn test_array_insert_range_left_overlap() {
         let mut store = Store::Array(vec![1, 2, 8, 9]);
 
-        let new = store.insert_range(2..6);
+        let new = store.insert_range(2..=5);
         assert_eq!(new, 3);
 
         assert_eq!(as_vec(store), vec![1, 2, 3, 4, 5, 8, 9]);
@@ -937,7 +930,7 @@ mod tests {
     fn test_array_insert_range_right_overlap() {
         let mut store = Store::Array(vec![1, 2, 8, 9]);
 
-        let new = store.insert_range(4..9);
+        let new = store.insert_range(4..=8);
         assert_eq!(new, 4);
 
         assert_eq!(as_vec(store), vec![1, 2, 4, 5, 6, 7, 8, 9]);
@@ -947,7 +940,7 @@ mod tests {
     fn test_array_insert_range_full_overlap() {
         let mut store = Store::Array(vec![1, 2, 8, 9]);
 
-        let new = store.insert_range(1..10);
+        let new = store.insert_range(1..=9);
         assert_eq!(new, 5);
 
         assert_eq!(as_vec(store), vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -960,7 +953,7 @@ mod tests {
         let mut store = store.to_bitmap();
 
         // Insert a range with start > end.
-        let new = store.insert_range(6..1);
+        let new = store.insert_range(6..=1);
         assert_eq!(new, 0);
 
         assert_eq!(as_vec(store), vec![1, 2, 8, 9]);
@@ -971,7 +964,7 @@ mod tests {
         let store = Store::Array(vec![1, 2, 3, 62, 63]);
         let mut store = store.to_bitmap();
 
-        let new = store.insert_range(1..63);
+        let new = store.insert_range(1..=62);
         assert_eq!(new, 58);
 
         assert_eq!(as_vec(store), (1..64).collect::<Vec<_>>());
@@ -982,7 +975,7 @@ mod tests {
         let store = Store::Array(vec![1, 2, 130]);
         let mut store = store.to_bitmap();
 
-        let new = store.insert_range(4..129);
+        let new = store.insert_range(4..=128);
         assert_eq!(new, 125);
 
         let mut want = vec![1, 2];
@@ -997,7 +990,7 @@ mod tests {
         let store = Store::Array(vec![1, 2, 130]);
         let mut store = store.to_bitmap();
 
-        let new = store.insert_range(1..129);
+        let new = store.insert_range(1..=128);
         assert_eq!(new, 126);
 
         let mut want = Vec::new();
@@ -1012,7 +1005,7 @@ mod tests {
         let store = Store::Array(vec![1, 2, 130]);
         let mut store = store.to_bitmap();
 
-        let new = store.insert_range(4..133);
+        let new = store.insert_range(4..=132);
         assert_eq!(new, 128);
 
         let mut want = vec![1, 2];
@@ -1026,7 +1019,7 @@ mod tests {
         let store = Store::Array(vec![1, 2, 130]);
         let mut store = store.to_bitmap();
 
-        let new = store.insert_range(1..135);
+        let new = store.insert_range(1..=134);
         assert_eq!(new, 131);
 
         let mut want = Vec::new();

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -15,13 +15,12 @@ pub fn join(high: u16, low: u16) -> u32 {
 }
 
 /// Convert a `RangeBounds<u32>` object to `RangeInclusive<u32>`,
-/// and return if the range is empty.
-pub fn convert_range_to_inclusive<R>(range: R) -> (RangeInclusive<u32>, bool)
+pub fn convert_range_to_inclusive<R>(range: R) -> Option<RangeInclusive<u32>>
 where
     R: RangeBounds<u32>,
 {
     if let Bound::Excluded(0) = range.end_bound() {
-        return (0..=0, true);
+        return None;
     }
     let start: u32 = match range.start_bound() {
         Bound::Included(&i) => i,
@@ -34,9 +33,9 @@ where
         Bound::Unbounded => u32::MAX,
     };
     if end < start {
-        return (0..=0, true);
+        return None;
     }
-    (start..=end, false)
+    Some(start..=end)
 }
 
 #[cfg(test)]

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -1,8 +1,12 @@
+/// Returns the container key and the index
+/// in this container for a given integer.
 #[inline]
 pub fn split(value: u32) -> (u16, u16) {
     ((value >> 16) as u16, value as u16)
 }
 
+/// Returns the original integer from the container
+/// key and the index of it in the container.
 #[inline]
 pub fn join(high: u16, low: u16) -> u32 {
     (u32::from(high) << 16) + u32::from(low)

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -1,3 +1,5 @@
+use std::ops::{Bound, RangeBounds, RangeInclusive};
+
 /// Returns the container key and the index
 /// in this container for a given integer.
 #[inline]
@@ -10,6 +12,31 @@ pub fn split(value: u32) -> (u16, u16) {
 #[inline]
 pub fn join(high: u16, low: u16) -> u32 {
     (u32::from(high) << 16) + u32::from(low)
+}
+
+/// Convert a `RangeBounds` object to `RangeInclusive<u32>`,
+/// and return if the range is empty.
+fn convert_range_to_inclusive<R>(range: R) -> (RangeInclusive<u32>, bool)
+where
+    R: RangeBounds<u32>,
+{
+    if let Bound::Excluded(0) = range.end_bound() {
+        return (0..=0, true);
+    }
+    let start: u32 = match range.start_bound() {
+        Bound::Included(&i) => i,
+        Bound::Unbounded => 0,
+        _ => panic!("Should never be called (insert_range start with Excluded)"),
+    };
+    let end: u32 = match range.end_bound() {
+        Bound::Included(&i) => i,
+        Bound::Excluded(&i) => i - 1,
+        Bound::Unbounded => u32::MAX,
+    };
+    if end < start {
+        return (0..=0, true);
+    }
+    (start..=end, false)
 }
 
 #[cfg(test)]

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -39,7 +39,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{join, split, convert_range_to_inclusive};
+    use super::{convert_range_to_inclusive, join, split};
 
     #[test]
     fn test_split_u32() {

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -14,9 +14,9 @@ pub fn join(high: u16, low: u16) -> u32 {
     (u32::from(high) << 16) + u32::from(low)
 }
 
-/// Convert a `RangeBounds` object to `RangeInclusive<u32>`,
+/// Convert a `RangeBounds<u32>` object to `RangeInclusive<u32>`,
 /// and return if the range is empty.
-fn convert_range_to_inclusive<R>(range: R) -> (RangeInclusive<u32>, bool)
+pub fn convert_range_to_inclusive<R>(range: R) -> (RangeInclusive<u32>, bool)
 where
     R: RangeBounds<u32>,
 {

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -105,13 +105,10 @@ impl RoaringTreemap {
     where
         R: RangeBounds<u64>,
     {
-        let (start, end);
-        if let Some(range) = util::convert_range_to_inclusive(range) {
-            start = *range.start();
-            end = *range.end();
-        } else {
-            return 0;
-        }
+        let (start, end) = match util::convert_range_to_inclusive(range) {
+            Some(range) => (*range.start(), *range.end()),
+            None => return 0,
+        };
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -118,16 +118,8 @@ impl RoaringTreemap {
 
         for (&key, rb) in &mut self.map {
             if key >= start_container_key && key <= end_container_key {
-                let a = if key == start_container_key {
-                    start_index
-                } else {
-                    0
-                };
-                let b = if key == end_container_key {
-                    end_index
-                } else {
-                    u32::max_value()
-                };
+                let a = if key == start_container_key { start_index } else { 0 };
+                let b = if key == end_container_key { end_index } else { u32::MAX };
                 removed += rb.remove_range(a..=b);
                 if rb.is_empty() {
                     keys_to_remove.push(key);

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -1,10 +1,10 @@
+use std::collections::btree_map::{BTreeMap, Entry};
+use std::ops::{Range, RangeInclusive};
+
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;
 
 use super::util;
-use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
-use std::ops::Range;
 
 impl RoaringTreemap {
     /// Creates an empty `RoaringTreemap`.
@@ -88,11 +88,8 @@ impl RoaringTreemap {
         }
     }
 
-    /// Removes a range of values from the set specific as [start..end).
+    /// Removes a range of values from the set.
     /// Returns the number of removed values.
-    ///
-    /// Note that due to the exclusive end you can't remove the item at the
-    /// last index (u64::MAX) using this function!
     ///
     /// # Examples
     ///
@@ -115,17 +112,19 @@ impl RoaringTreemap {
         let (end_hi, end_lo) = util::split(range.end - 1);
         for (&key, rb) in &mut self.map {
             if key >= start_hi && key <= end_hi {
-                let a = if key == start_hi { u64::from(start_lo) } else { 0 };
-                let b = if key == end_hi {
-                    u64::from(end_lo) + 1 // make it exclusive
+                let start = if key == start_hi { start_lo } else { 0 };
+                let end = if key == end_hi {
+                    end_lo
                 } else {
-                    u64::from(u32::max_value()) + 1
+                    u32::max_value()
                 };
-                if a == 0 && b == u64::from(u32::max_value()) + 1 {
+                let range = RangeInclusive::new(start, end);
+
+                if key != start_hi && key != end_lo {
                     removed += rb.len();
                     keys_to_remove.push(key);
                 } else {
-                    removed += rb.remove_range(a..b);
+                    removed += rb.remove_range(range);
                     if rb.is_empty() {
                         keys_to_remove.push(key);
                     }

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -105,13 +105,13 @@ impl RoaringTreemap {
     where
         R: RangeBounds<u64>,
     {
-        let (range, is_empty) = util::convert_range_to_inclusive(range);
-        if is_empty {
+        let (start, end);
+        if let Some(range) = util::convert_range_to_inclusive(range) {
+            start = *range.start();
+            end = *range.end();
+        } else {
             return 0;
         }
-
-        let start = *range.start();
-        let end = *range.end();
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -1,5 +1,5 @@
 use std::collections::btree_map::{BTreeMap, Entry};
-use std::ops::{Bound, Range, RangeBounds, RangeInclusive};
+use std::ops::RangeBounds;
 
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;
@@ -105,27 +105,13 @@ impl RoaringTreemap {
     where
         R: RangeBounds<u64>,
     {
-        // Get Range's inclusive start and end point.
-        let mut start: u64 = match range.start_bound() {
-            Bound::Included(&i) => i,
-            Bound::Unbounded => 0,
-            _ => panic!("Should never be called (remove_range start with Excluded)"),
-        };
-        let end: u64 = match range.end_bound() {
-            Bound::Included(&i) => i,
-            Bound::Excluded(0) => {
-                // Make this range empty with start > end
-                start = u64::MAX;
-                0
-            }
-            Bound::Excluded(&i) => i - 1,
-            Bound::Unbounded => u64::MAX,
-        };
-        let start = start;
-
-        if end < start {
+        let (range, is_empty) = util::convert_range_to_inclusive(range);
+        if is_empty {
             return 0;
         }
+
+        let start = *range.start();
+        let end = *range.end();
 
         let (start_container_key, start_index) = util::split(start);
         let (end_container_key, end_index) = util::split(end);

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -88,10 +88,10 @@ impl<'a> Iterator for Iter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.size_hint < usize::max_value() as u64 {
+        if self.size_hint < usize::MAX as u64 {
             (self.size_hint as usize, Some(self.size_hint as usize))
         } else {
-            (usize::max_value(), None)
+            (usize::MAX, None)
         }
     }
 }
@@ -105,10 +105,10 @@ impl Iterator for IntoIter {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.size_hint < usize::max_value() as u64 {
+        if self.size_hint < usize::MAX as u64 {
             (self.size_hint as usize, Some(self.size_hint as usize))
         } else {
-            (usize::max_value(), None)
+            (usize::MAX, None)
         }
     }
 }

--- a/src/treemap/util.rs
+++ b/src/treemap/util.rs
@@ -1,3 +1,5 @@
+use std::ops::{Bound, RangeBounds, RangeInclusive};
+
 #[inline]
 pub fn split(value: u64) -> (u32, u32) {
     ((value >> 32) as u32, value as u32)
@@ -6,6 +8,31 @@ pub fn split(value: u64) -> (u32, u32) {
 #[inline]
 pub fn join(high: u32, low: u32) -> u64 {
     (u64::from(high) << 32) | u64::from(low)
+}
+
+/// Convert a `RangeBounds<u64>` object to `RangeInclusive<u64>`,
+/// and return if the range is empty.
+pub fn convert_range_to_inclusive<R>(range: R) -> (RangeInclusive<u64>, bool)
+where
+    R: RangeBounds<u64>,
+{
+    if let Bound::Excluded(0) = range.end_bound() {
+        return (0..=0, true);
+    }
+    let start: u64 = match range.start_bound() {
+        Bound::Included(&i) => i,
+        Bound::Unbounded => 0,
+        _ => panic!("Should never be called (insert_range start with Excluded)"),
+    };
+    let end: u64 = match range.end_bound() {
+        Bound::Included(&i) => i,
+        Bound::Excluded(&i) => i - 1,
+        Bound::Unbounded => u64::MAX,
+    };
+    if end < start {
+        return (0..=0, true);
+    }
+    (start..=end, false)
 }
 
 #[cfg(test)]

--- a/src/treemap/util.rs
+++ b/src/treemap/util.rs
@@ -35,7 +35,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{join, split, convert_range_to_inclusive};
+    use super::{convert_range_to_inclusive, join, split};
 
     #[test]
     fn test_split_u64() {

--- a/src/treemap/util.rs
+++ b/src/treemap/util.rs
@@ -11,13 +11,12 @@ pub fn join(high: u32, low: u32) -> u64 {
 }
 
 /// Convert a `RangeBounds<u64>` object to `RangeInclusive<u64>`,
-/// and return if the range is empty.
-pub fn convert_range_to_inclusive<R>(range: R) -> (RangeInclusive<u64>, bool)
+pub fn convert_range_to_inclusive<R>(range: R) -> Option<RangeInclusive<u64>>
 where
     R: RangeBounds<u64>,
 {
     if let Bound::Excluded(0) = range.end_bound() {
-        return (0..=0, true);
+        return None;
     }
     let start: u64 = match range.start_bound() {
         Bound::Included(&i) => i,
@@ -30,9 +29,9 @@ where
         Bound::Unbounded => u64::MAX,
     };
     if end < start {
-        return (0..=0, true);
+        return None;
     }
-    (start..=end, false)
+    Some(start..=end)
 }
 
 #[cfg(test)]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -39,7 +39,7 @@ fn remove_range() {
     for (i, &a) in ranges.iter().enumerate() {
         for &b in &ranges[i..] {
             let mut bitmap = (0..=65536).collect::<RoaringBitmap>();
-            assert_eq!(bitmap.remove_range(u64::from(a)..u64::from(b)), u64::from(b - a));
+            assert_eq!(bitmap.remove_range(a..b), u64::from(b - a));
             assert_eq!(bitmap, (0..a).chain(b..=65536).collect::<RoaringBitmap>());
         }
     }


### PR DESCRIPTION
This PR fixes #5 by reworking the `Bitmap::insert_range` and `Bitmap::remove_range` functions to accept any type that implement [the `RangeBounds` trait](https://doc.rust-lang.org/nightly/core/ops/trait.RangeBounds.html). Note that it is a breaking change and therefore involves bumping the crate version carefully.

The current version of all these functions was accepting an [exclusive `Range<u64>`](https://doc.rust-lang.org/nightly/core/ops/struct.Range.html) to let user define all possible integers in the range `0` to `u32::MAX`, but as it is an exclusive range, a `u64` was required.

@josephglanville, could you please take a look at this PR? When you got time 😃