### PR TITLE
Optimize the BitAnd/Assign and BitOr/Assign operations

### DIFF
--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -217,47 +217,61 @@ impl<'a> BitOrAssign<&'a RoaringBitmap> for RoaringBitmap {
 }
 
 impl BitAnd<RoaringBitmap> for RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+    type Output = RoaringBitmap;
 
-    fn bitand(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
-        self.intersect_with(&rhs);
-        self
+    fn bitand(mut self, mut rhs: RoaringBitmap) -> RoaringBitmap {
+        if self.len() <= rhs.len() {
+            self.intersect_with(&rhs);
+            self
+        } else {
+            rhs.intersect_with(&self);
+            rhs
+        }
     }
 }
 
-impl<'a> BitAnd<&'a RoaringBitmap> for RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitAnd<&RoaringBitmap> for RoaringBitmap {
+    type Output = RoaringBitmap;
 
-    fn bitand(mut self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
+    fn bitand(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.intersect_with(rhs);
         self
     }
 }
 
-impl<'a> BitAnd<RoaringBitmap> for &'a RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitAnd<RoaringBitmap> for &RoaringBitmap {
+    type Output = RoaringBitmap;
 
     fn bitand(self, rhs: RoaringBitmap) -> RoaringBitmap {
         rhs & self
     }
 }
 
-impl<'a, 'b> BitAnd<&'a RoaringBitmap> for &'b RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
+    type Output = RoaringBitmap;
 
-    fn bitand(self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
-        self.clone() & rhs
+    fn bitand(self, rhs: &RoaringBitmap) -> RoaringBitmap {
+        if self.len() <= rhs.len() {
+            self.clone() & rhs
+        } else {
+            rhs.clone() & self
+        }
     }
 }
 
 impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
-    fn bitand_assign(&mut self, rhs: RoaringBitmap) {
-        self.intersect_with(&rhs)
+    fn bitand_assign(&mut self, mut rhs: RoaringBitmap) {
+        if self.len() <= rhs.len() {
+            self.intersect_with(&rhs);
+        } else {
+            rhs.intersect_with(self);
+            *self = rhs;
+        }
     }
 }
 
-impl<'a> BitAndAssign<&'a RoaringBitmap> for RoaringBitmap {
-    fn bitand_assign(&mut self, rhs: &'a RoaringBitmap) {
+impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
+    fn bitand_assign(&mut self, rhs: &RoaringBitmap) {
         self.intersect_with(rhs)
     }
 }

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -171,47 +171,61 @@ impl RoaringBitmap {
 }
 
 impl BitOr<RoaringBitmap> for RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+    type Output = RoaringBitmap;
 
-    fn bitor(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
-        self.union_with(&rhs);
-        self
+    fn bitor(mut self, mut rhs: RoaringBitmap) -> RoaringBitmap {
+        if self.len() <= rhs.len() {
+            rhs.union_with(&self);
+            rhs
+        } else {
+            self.union_with(&rhs);
+            self
+        }
     }
 }
 
-impl<'a> BitOr<&'a RoaringBitmap> for RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitOr<&RoaringBitmap> for RoaringBitmap {
+    type Output = RoaringBitmap;
 
-    fn bitor(mut self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
+    fn bitor(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.union_with(rhs);
         self
     }
 }
 
-impl<'a> BitOr<RoaringBitmap> for &'a RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitOr<RoaringBitmap> for &RoaringBitmap {
+    type Output = RoaringBitmap;
 
     fn bitor(self, rhs: RoaringBitmap) -> RoaringBitmap {
         rhs | self
     }
 }
 
-impl<'a, 'b> BitOr<&'a RoaringBitmap> for &'b RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitOr<&RoaringBitmap> for &RoaringBitmap {
+    type Output = RoaringBitmap;
 
-    fn bitor(self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
-        self.clone() | rhs
+    fn bitor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
+        if self.len() <= rhs.len() {
+            rhs.clone() | self
+        } else {
+            self.clone() | rhs
+        }
     }
 }
 
 impl BitOrAssign<RoaringBitmap> for RoaringBitmap {
-    fn bitor_assign(&mut self, rhs: RoaringBitmap) {
-        self.union_with(&rhs)
+    fn bitor_assign(&mut self, mut rhs: RoaringBitmap) {
+        if self.len() <= rhs.len() {
+            rhs.union_with(&self);
+            *self = rhs;
+        } else {
+            self.union_with(&rhs);
+        }
     }
 }
 
-impl<'a> BitOrAssign<&'a RoaringBitmap> for RoaringBitmap {
-    fn bitor_assign(&mut self, rhs: &'a RoaringBitmap) {
+impl BitOrAssign<&RoaringBitmap> for RoaringBitmap {
+    fn bitor_assign(&mut self, rhs: &RoaringBitmap) {
         self.union_with(rhs)
     }
 }


### PR DESCRIPTION
This is a successful attempt at optimizing the `&`, `&=`, `|`, and `|=` by making sure that we do the operation on the smallest or biggest roaring bitmap depending on the operation.

There is room for a lot more optimization in the union operation (i.e. `&`, `&=`) where the containers that don't exist on one side are cloned from the other side instead of being extracted when the other side is owned and will be dropped anyway.
I have [filled an issue](https://github.com/RoaringBitmap/roaring-rs/issues/95) with my concerns about the future of the `intersect_with`, `union_with`... `RoaringBitmap` methods and the equivalent on the internal `Container`/`Store` structs.