### PR TITLE
Replace set ops literal methods (`intersect_with`...) by the Rust std ops traits (`BitAnd`...)

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -104,7 +104,7 @@ fn intersect_with(c: &mut Criterion) {
         let bitmap2: RoaringBitmap = (100..200).collect();
 
         b.iter(|| {
-            bitmap1.intersect_with(black_box(&bitmap2));
+            bitmap1 &= black_box(&bitmap2);
         });
     });
 }
@@ -124,7 +124,7 @@ fn union_with(c: &mut Criterion) {
         let bitmap2: RoaringBitmap = (100..200).collect();
 
         b.iter(|| {
-            bitmap1.union_with(black_box(&bitmap2));
+            bitmap1 |= black_box(&bitmap2);
         });
     });
 }
@@ -144,7 +144,7 @@ fn symmetric_deference_with(c: &mut Criterion) {
         let bitmap2: RoaringBitmap = (100..200).collect();
 
         b.iter(|| {
-            bitmap1.symmetric_difference_with(black_box(&bitmap2));
+            bitmap1 ^= black_box(&bitmap2);
         });
     });
 }

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::BitOrAssign;
+use std::ops::{BitAndAssign, BitOrAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -105,9 +105,7 @@ impl Container {
         note = "Please use the `BitAndAssign::bitand_assign` ops method instead"
     )]
     pub fn intersect_with(&mut self, other: &Self) {
-        self.store.intersect_with(&other.store);
-        self.len = self.store.len();
-        self.ensure_correct_store();
+        BitAndAssign::bitand_assign(self, other)
     }
 
     #[deprecated(
@@ -161,6 +159,22 @@ impl BitOrAssign<Container> for Container {
 impl BitOrAssign<&Container> for Container {
     fn bitor_assign(&mut self, rhs: &Container) {
         BitOrAssign::bitor_assign(&mut self.store, &rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
+    }
+}
+
+impl BitAndAssign<Container> for Container {
+    fn bitand_assign(&mut self, rhs: Container) {
+        BitAndAssign::bitand_assign(&mut self.store, rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
+    }
+}
+
+impl BitAndAssign<&Container> for Container {
+    fn bitand_assign(&mut self, rhs: &Container) {
+        BitAndAssign::bitand_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
     }

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -91,24 +91,40 @@ impl Container {
         self.len <= other.len && self.store.is_subset(&other.store)
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitOrAssign::bitor_assign` ops method instead",
+    )]
     pub fn union_with(&mut self, other: &Self) {
         self.store.union_with(&other.store);
         self.len = self.store.len();
         self.ensure_correct_store();
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitAndAssign::bitand_assign` ops method instead",
+    )]
     pub fn intersect_with(&mut self, other: &Self) {
         self.store.intersect_with(&other.store);
         self.len = self.store.len();
         self.ensure_correct_store();
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `SubAssign::sub_assign` ops method instead",
+    )]
     pub fn difference_with(&mut self, other: &Self) {
         self.store.difference_with(&other.store);
         self.len = self.store.len();
         self.ensure_correct_store();
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead",
+    )]
     pub fn symmetric_difference_with(&mut self, other: &Self) {
         self.store.symmetric_difference_with(&other.store);
         self.len = self.store.len();

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,3 +1,4 @@
+use std::ops::BitOrAssign;
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -93,17 +94,15 @@ impl Container {
 
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitOrAssign::bitor_assign` ops method instead",
+        note = "Please use the `BitOrAssign::bitor_assign` ops method instead"
     )]
     pub fn union_with(&mut self, other: &Self) {
-        self.store.union_with(&other.store);
-        self.len = self.store.len();
-        self.ensure_correct_store();
+        BitOrAssign::bitor_assign(self, other)
     }
 
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitAndAssign::bitand_assign` ops method instead",
+        note = "Please use the `BitAndAssign::bitand_assign` ops method instead"
     )]
     pub fn intersect_with(&mut self, other: &Self) {
         self.store.intersect_with(&other.store);
@@ -113,7 +112,7 @@ impl Container {
 
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `SubAssign::sub_assign` ops method instead",
+        note = "Please use the `SubAssign::sub_assign` ops method instead"
     )]
     pub fn difference_with(&mut self, other: &Self) {
         self.store.difference_with(&other.store);
@@ -123,7 +122,7 @@ impl Container {
 
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead",
+        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead"
     )]
     pub fn symmetric_difference_with(&mut self, other: &Self) {
         self.store.symmetric_difference_with(&other.store);
@@ -148,6 +147,22 @@ impl Container {
         if let Some(new_store) = new_store {
             self.store = new_store;
         }
+    }
+}
+
+impl BitOrAssign<Container> for Container {
+    fn bitor_assign(&mut self, rhs: Container) {
+        BitOrAssign::bitor_assign(&mut self.store, rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
+    }
+}
+
+impl BitOrAssign<&Container> for Container {
+    fn bitor_assign(&mut self, rhs: &Container) {
+        BitOrAssign::bitor_assign(&mut self.store, &rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
     }
 }
 

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAndAssign, BitOrAssign, SubAssign};
+use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -121,9 +121,7 @@ impl Container {
         note = "Please use the `BitXorAssign::bitxor_assign` ops method instead"
     )]
     pub fn symmetric_difference_with(&mut self, other: &Self) {
-        self.store.symmetric_difference_with(&other.store);
-        self.len = self.store.len();
-        self.ensure_correct_store();
+        BitXorAssign::bitxor_assign(self, other)
     }
 
     pub fn min(&self) -> u16 {
@@ -181,6 +179,22 @@ impl BitAndAssign<&Container> for Container {
 impl SubAssign<&Container> for Container {
     fn sub_assign(&mut self, rhs: &Container) {
         SubAssign::sub_assign(&mut self.store, &rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
+    }
+}
+
+impl BitXorAssign<Container> for Container {
+    fn bitxor_assign(&mut self, rhs: Container) {
+        BitXorAssign::bitxor_assign(&mut self.store, rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
+    }
+}
+
+impl BitXorAssign<&Container> for Container {
+    fn bitxor_assign(&mut self, rhs: &Container) {
+        BitXorAssign::bitxor_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
     }

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAndAssign, BitOrAssign};
+use std::ops::{BitAndAssign, BitOrAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -113,9 +113,7 @@ impl Container {
         note = "Please use the `SubAssign::sub_assign` ops method instead"
     )]
     pub fn difference_with(&mut self, other: &Self) {
-        self.store.difference_with(&other.store);
-        self.len = self.store.len();
-        self.ensure_correct_store();
+        SubAssign::sub_assign(self, other)
     }
 
     #[deprecated(
@@ -175,6 +173,14 @@ impl BitAndAssign<Container> for Container {
 impl BitAndAssign<&Container> for Container {
     fn bitand_assign(&mut self, rhs: &Container) {
         BitAndAssign::bitand_assign(&mut self.store, &rhs.store);
+        self.len = self.store.len();
+        self.ensure_correct_store();
+    }
+}
+
+impl SubAssign<&Container> for Container {
+    fn sub_assign(&mut self, rhs: &Container) {
+        SubAssign::sub_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
     }

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -92,38 +92,6 @@ impl Container {
         self.len <= other.len && self.store.is_subset(&other.store)
     }
 
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `BitOrAssign::bitor_assign` ops method instead"
-    )]
-    pub fn union_with(&mut self, other: &Self) {
-        BitOrAssign::bitor_assign(self, other)
-    }
-
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `BitAndAssign::bitand_assign` ops method instead"
-    )]
-    pub fn intersect_with(&mut self, other: &Self) {
-        BitAndAssign::bitand_assign(self, other)
-    }
-
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `SubAssign::sub_assign` ops method instead"
-    )]
-    pub fn difference_with(&mut self, other: &Self) {
-        SubAssign::sub_assign(self, other)
-    }
-
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead"
-    )]
-    pub fn symmetric_difference_with(&mut self, other: &Self) {
-        BitXorAssign::bitxor_assign(self, other)
-    }
-
     pub fn min(&self) -> u16 {
         self.store.min()
     }

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -33,6 +33,10 @@ impl RoaringBitmap {
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitOrAssign::or_assign` ops method instead",
+    )]
     pub fn union_with(&mut self, other: &RoaringBitmap) {
         for container in &other.containers {
             let key = container.key;
@@ -72,6 +76,10 @@ impl RoaringBitmap {
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitAndAssign::and_assign` ops method instead",
+    )]
     pub fn intersect_with(&mut self, other: &RoaringBitmap) {
         self.containers.retain_mut(|cont| {
             match other.containers.binary_search_by_key(&cont.key, |c| c.key) {
@@ -113,6 +121,10 @@ impl RoaringBitmap {
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `SubAssign::sub_assign` ops method instead",
+    )]
     pub fn difference_with(&mut self, other: &RoaringBitmap) {
         self.containers.retain_mut(|cont| {
             match other.containers.binary_search_by_key(&cont.key, |c| c.key) {
@@ -154,6 +166,10 @@ impl RoaringBitmap {
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitXorAssign::xor_assign` ops method instead",
+    )]
     pub fn symmetric_difference_with(&mut self, other: &RoaringBitmap) {
         for container in &other.containers {
             let key = container.key;

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -189,6 +189,7 @@ impl RoaringBitmap {
 impl BitOr<RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `union` between both maps.
     fn bitor(mut self, mut rhs: RoaringBitmap) -> RoaringBitmap {
         if self.len() <= rhs.len() {
             rhs.union_with(&self);
@@ -203,6 +204,7 @@ impl BitOr<RoaringBitmap> for RoaringBitmap {
 impl BitOr<&RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `union` between both maps.
     fn bitor(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.union_with(rhs);
         self
@@ -212,6 +214,7 @@ impl BitOr<&RoaringBitmap> for RoaringBitmap {
 impl BitOr<RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `union` between both maps.
     fn bitor(self, rhs: RoaringBitmap) -> RoaringBitmap {
         rhs | self
     }
@@ -220,6 +223,7 @@ impl BitOr<RoaringBitmap> for &RoaringBitmap {
 impl BitOr<&RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `union` between both maps.
     fn bitor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         if self.len() <= rhs.len() {
             rhs.clone() | self
@@ -230,6 +234,7 @@ impl BitOr<&RoaringBitmap> for &RoaringBitmap {
 }
 
 impl BitOrAssign<RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to an `union` between both maps.
     fn bitor_assign(&mut self, mut rhs: RoaringBitmap) {
         if self.len() <= rhs.len() {
             rhs.union_with(&self);
@@ -241,6 +246,7 @@ impl BitOrAssign<RoaringBitmap> for RoaringBitmap {
 }
 
 impl BitOrAssign<&RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to an `union` between both maps.
     fn bitor_assign(&mut self, rhs: &RoaringBitmap) {
         self.union_with(rhs)
     }
@@ -249,6 +255,7 @@ impl BitOrAssign<&RoaringBitmap> for RoaringBitmap {
 impl BitAnd<RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `intersection` between both maps.
     fn bitand(mut self, mut rhs: RoaringBitmap) -> RoaringBitmap {
         if self.len() <= rhs.len() {
             self.intersect_with(&rhs);
@@ -263,6 +270,7 @@ impl BitAnd<RoaringBitmap> for RoaringBitmap {
 impl BitAnd<&RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `intersection` between both maps.
     fn bitand(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.intersect_with(rhs);
         self
@@ -272,6 +280,7 @@ impl BitAnd<&RoaringBitmap> for RoaringBitmap {
 impl BitAnd<RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `intersection` between both maps.
     fn bitand(self, rhs: RoaringBitmap) -> RoaringBitmap {
         rhs & self
     }
@@ -280,6 +289,7 @@ impl BitAnd<RoaringBitmap> for &RoaringBitmap {
 impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
+    /// This is equivalent to an `intersection` between both maps.
     fn bitand(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         if self.len() <= rhs.len() {
             self.clone() & rhs
@@ -290,6 +300,7 @@ impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
 }
 
 impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to an `intersection` between both maps.
     fn bitand_assign(&mut self, mut rhs: RoaringBitmap) {
         if self.len() <= rhs.len() {
             self.intersect_with(&rhs);
@@ -301,6 +312,7 @@ impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
 }
 
 impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to an `intersection` between both maps.
     fn bitand_assign(&mut self, rhs: &RoaringBitmap) {
         self.intersect_with(rhs)
     }
@@ -309,45 +321,51 @@ impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
 impl Sub<RoaringBitmap> for RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
+    /// This is equivalent to a `difference` between both maps.
     fn sub(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
         self.difference_with(&rhs);
         self
     }
 }
 
-impl<'a> Sub<&'a RoaringBitmap> for RoaringBitmap {
+impl Sub<&RoaringBitmap> for RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
-    fn sub(mut self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
+    /// This is equivalent to a `difference` between both maps.
+    fn sub(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.difference_with(rhs);
         self
     }
 }
 
-impl<'a> Sub<RoaringBitmap> for &'a RoaringBitmap {
+impl Sub<RoaringBitmap> for &RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
+    /// This is equivalent to a `difference` between both maps.
     fn sub(self, rhs: RoaringBitmap) -> RoaringBitmap {
         self.clone() - rhs
     }
 }
 
-impl<'a, 'b> Sub<&'a RoaringBitmap> for &'b RoaringBitmap {
+impl Sub<&RoaringBitmap> for &RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
-    fn sub(self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
+    /// This is equivalent to a `difference` between both maps.
+    fn sub(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.clone() - rhs
     }
 }
 
 impl SubAssign<RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to a `difference` between both maps.
     fn sub_assign(&mut self, rhs: RoaringBitmap) {
         self.difference_with(&rhs)
     }
 }
 
-impl<'a> SubAssign<&'a RoaringBitmap> for RoaringBitmap {
-    fn sub_assign(&mut self, rhs: &'a RoaringBitmap) {
+impl SubAssign<&RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to a `difference` between both maps.
+    fn sub_assign(&mut self, rhs: &RoaringBitmap) {
         self.difference_with(rhs)
     }
 }
@@ -355,45 +373,51 @@ impl<'a> SubAssign<&'a RoaringBitmap> for RoaringBitmap {
 impl BitXor<RoaringBitmap> for RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
+    /// This is equivalent to a `symmetric difference` between both maps.
     fn bitxor(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
         self.symmetric_difference_with(&rhs);
         self
     }
 }
 
-impl<'a> BitXor<&'a RoaringBitmap> for RoaringBitmap {
+impl BitXor<&RoaringBitmap> for RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
-    fn bitxor(mut self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
+    /// This is equivalent to a `symmetric difference` between both maps.
+    fn bitxor(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.symmetric_difference_with(rhs);
         self
     }
 }
 
-impl<'a> BitXor<RoaringBitmap> for &'a RoaringBitmap {
+impl BitXor<RoaringBitmap> for &RoaringBitmap {
     type Output = crate::RoaringBitmap;
 
+    /// This is equivalent to a `symmetric difference` between both maps.
     fn bitxor(self, rhs: RoaringBitmap) -> RoaringBitmap {
         rhs ^ self
     }
 }
 
-impl<'a, 'b> BitXor<&'a RoaringBitmap> for &'b RoaringBitmap {
-    type Output = crate::RoaringBitmap;
+impl BitXor<&RoaringBitmap> for &RoaringBitmap {
+    type Output = RoaringBitmap;
 
-    fn bitxor(self, rhs: &'a RoaringBitmap) -> RoaringBitmap {
+    /// This is equivalent to a `symmetric difference` between both maps.
+    fn bitxor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         self.clone() ^ rhs
     }
 }
 
 impl BitXorAssign<RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to a `symmetric difference` between both maps.
     fn bitxor_assign(&mut self, rhs: RoaringBitmap) {
         self.symmetric_difference_with(&rhs)
     }
 }
 
-impl<'a> BitXorAssign<&'a RoaringBitmap> for RoaringBitmap {
-    fn bitxor_assign(&mut self, rhs: &'a RoaringBitmap) {
+impl BitXorAssign<&RoaringBitmap> for RoaringBitmap {
+    /// This is equivalent to a `symmetric difference` between both maps.
+    fn bitxor_assign(&mut self, rhs: &RoaringBitmap) {
         self.symmetric_difference_with(rhs)
     }
 }

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -39,7 +39,7 @@ impl RoaringBitmap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitOrAssign::bitor_assign` ops method instead"
+        note = "Please use the `BitOrAssign::bitor_assign` (`|=`) ops method instead"
     )]
     pub fn union_with(&mut self, other: &RoaringBitmap) {
         BitOrAssign::bitor_assign(self, other)
@@ -76,7 +76,7 @@ impl RoaringBitmap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitAndAssign::bitand_assign` ops method instead"
+        note = "Please use the `BitAndAssign::bitand_assign` (`&=`) ops method instead"
     )]
     pub fn intersect_with(&mut self, other: &RoaringBitmap) {
         BitAndAssign::bitand_assign(self, other)
@@ -113,7 +113,7 @@ impl RoaringBitmap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `SubAssign::sub_assign` ops method instead"
+        note = "Please use the `SubAssign::sub_assign` (`-=`) ops method instead"
     )]
     pub fn difference_with(&mut self, other: &RoaringBitmap) {
         SubAssign::sub_assign(self, other)
@@ -150,7 +150,7 @@ impl RoaringBitmap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead"
+        note = "Please use the `BitXorAssign::bitxor_assign` (`^=`) ops method instead"
     )]
     pub fn symmetric_difference_with(&mut self, other: &RoaringBitmap) {
         BitXorAssign::bitxor_assign(self, other)
@@ -160,7 +160,7 @@ impl RoaringBitmap {
 impl BitOr<RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
         BitOrAssign::bitor_assign(&mut self, rhs);
         self
@@ -170,7 +170,7 @@ impl BitOr<RoaringBitmap> for RoaringBitmap {
 impl BitOr<&RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         BitOrAssign::bitor_assign(&mut self, rhs);
         self
@@ -180,7 +180,7 @@ impl BitOr<&RoaringBitmap> for RoaringBitmap {
 impl BitOr<RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(self, rhs: RoaringBitmap) -> RoaringBitmap {
         BitOr::bitor(rhs, self)
     }
@@ -189,7 +189,7 @@ impl BitOr<RoaringBitmap> for &RoaringBitmap {
 impl BitOr<&RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         if self.len() <= rhs.len() {
             BitOr::bitor(rhs.clone(), self)
@@ -200,7 +200,7 @@ impl BitOr<&RoaringBitmap> for &RoaringBitmap {
 }
 
 impl BitOrAssign<RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor_assign(&mut self, mut rhs: RoaringBitmap) {
         // We make sure that we apply the union operation on the biggest map.
         if self.len() < rhs.len() {
@@ -218,7 +218,7 @@ impl BitOrAssign<RoaringBitmap> for RoaringBitmap {
 }
 
 impl BitOrAssign<&RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor_assign(&mut self, rhs: &RoaringBitmap) {
         for container in &rhs.containers {
             let key = container.key;
@@ -233,7 +233,7 @@ impl BitOrAssign<&RoaringBitmap> for RoaringBitmap {
 impl BitAnd<RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
         BitAndAssign::bitand_assign(&mut self, rhs);
         self
@@ -243,7 +243,7 @@ impl BitAnd<RoaringBitmap> for RoaringBitmap {
 impl BitAnd<&RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         BitAndAssign::bitand_assign(&mut self, rhs);
         self
@@ -253,7 +253,7 @@ impl BitAnd<&RoaringBitmap> for RoaringBitmap {
 impl BitAnd<RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(self, rhs: RoaringBitmap) -> RoaringBitmap {
         BitAnd::bitand(rhs, self)
     }
@@ -262,7 +262,7 @@ impl BitAnd<RoaringBitmap> for &RoaringBitmap {
 impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         if rhs.len() < self.len() {
             BitAnd::bitand(self.clone(), rhs)
@@ -273,7 +273,7 @@ impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
 }
 
 impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand_assign(&mut self, mut rhs: RoaringBitmap) {
         // We make sure that we apply the intersection operation on the smallest map.
         if rhs.len() < self.len() {
@@ -296,7 +296,7 @@ impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
 }
 
 impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand_assign(&mut self, rhs: &RoaringBitmap) {
         self.containers.retain_mut(|cont| {
             let key = cont.key;
@@ -314,7 +314,7 @@ impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
 impl Sub<RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
         SubAssign::sub_assign(&mut self, &rhs);
         self
@@ -324,7 +324,7 @@ impl Sub<RoaringBitmap> for RoaringBitmap {
 impl Sub<&RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         SubAssign::sub_assign(&mut self, rhs);
         self
@@ -334,7 +334,7 @@ impl Sub<&RoaringBitmap> for RoaringBitmap {
 impl Sub<RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(self, rhs: RoaringBitmap) -> RoaringBitmap {
         Sub::sub(self.clone(), rhs)
     }
@@ -343,21 +343,21 @@ impl Sub<RoaringBitmap> for &RoaringBitmap {
 impl Sub<&RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         Sub::sub(self.clone(), rhs)
     }
 }
 
 impl SubAssign<RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub_assign(&mut self, rhs: RoaringBitmap) {
         SubAssign::sub_assign(self, &rhs)
     }
 }
 
 impl SubAssign<&RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub_assign(&mut self, rhs: &RoaringBitmap) {
         self.containers.retain_mut(|cont| {
             match rhs.containers.binary_search_by_key(&cont.key, |c| c.key) {
@@ -374,7 +374,7 @@ impl SubAssign<&RoaringBitmap> for RoaringBitmap {
 impl BitXor<RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(mut self, rhs: RoaringBitmap) -> RoaringBitmap {
         BitXorAssign::bitxor_assign(&mut self, rhs);
         self
@@ -384,7 +384,7 @@ impl BitXor<RoaringBitmap> for RoaringBitmap {
 impl BitXor<&RoaringBitmap> for RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(mut self, rhs: &RoaringBitmap) -> RoaringBitmap {
         BitXorAssign::bitxor_assign(&mut self, rhs);
         self
@@ -394,7 +394,7 @@ impl BitXor<&RoaringBitmap> for RoaringBitmap {
 impl BitXor<RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(self, rhs: RoaringBitmap) -> RoaringBitmap {
         BitXor::bitxor(rhs, self)
     }
@@ -403,7 +403,7 @@ impl BitXor<RoaringBitmap> for &RoaringBitmap {
 impl BitXor<&RoaringBitmap> for &RoaringBitmap {
     type Output = RoaringBitmap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
         if self.len() < rhs.len() {
             BitXor::bitxor(self, rhs.clone())
@@ -414,7 +414,7 @@ impl BitXor<&RoaringBitmap> for &RoaringBitmap {
 }
 
 impl BitXorAssign<RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor_assign(&mut self, rhs: RoaringBitmap) {
         let mut left = mem::take(&mut self.containers).into_iter().peekable();
         let mut right = rhs.containers.into_iter().peekable();
@@ -454,7 +454,7 @@ impl BitXorAssign<RoaringBitmap> for RoaringBitmap {
 }
 
 impl BitXorAssign<&RoaringBitmap> for RoaringBitmap {
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor_assign(&mut self, rhs: &RoaringBitmap) {
         let mut left = mem::take(&mut self.containers).into_iter().peekable();
         let mut right = rhs.containers.iter().peekable();

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -19,7 +19,7 @@ impl RoaringBitmap {
     /// let rb2: RoaringBitmap = (3..5).collect();
     /// let rb3: RoaringBitmap = (1..5).collect();
     ///
-    /// rb1.union_with(&rb2);
+    /// rb1 |= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
@@ -56,7 +56,7 @@ impl RoaringBitmap {
     /// let rb2: RoaringBitmap = (3..5).collect();
     /// let rb3: RoaringBitmap = (3..4).collect();
     ///
-    /// rb1.intersect_with(&rb2);
+    /// rb1 &= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
@@ -93,7 +93,7 @@ impl RoaringBitmap {
     /// let rb2: RoaringBitmap = (3..5).collect();
     /// let rb3: RoaringBitmap = (1..3).collect();
     ///
-    /// rb1.difference_with(&rb2);
+    /// rb1 -= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
@@ -130,7 +130,7 @@ impl RoaringBitmap {
     /// let rb2: RoaringBitmap = (3..6).collect();
     /// let rb3: RoaringBitmap = (1..3).chain(4..6).collect();
     ///
-    /// rb1.symmetric_difference_with(&rb2);
+    /// rb1 ^= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -284,6 +284,10 @@ impl Store {
         }
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitOrAssign::bitor_assign` ops method instead",
+    )]
     pub fn union_with(&mut self, other: &Self) {
         match (self, other) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {
@@ -341,6 +345,10 @@ impl Store {
         }
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitAndAssign::bitand_assign` ops method instead",
+    )]
     pub fn intersect_with(&mut self, other: &Self) {
         match (self, other) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {
@@ -374,6 +382,10 @@ impl Store {
         }
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `SubAssign::sub_assign` ops method instead",
+    )]
     pub fn difference_with(&mut self, other: &Self) {
         match (self, other) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {
@@ -403,6 +415,10 @@ impl Store {
         }
     }
 
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead",
+    )]
     pub fn symmetric_difference_with(&mut self, other: &Self) {
         match (self, other) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -368,6 +368,7 @@ impl BitOrAssign<&Store> for Store {
 }
 
 impl BitAndAssign<Store> for Store {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn bitand_assign(&mut self, mut rhs: Store) {
         match (self, &mut rhs) {
             (&mut Array(ref mut lhs), &mut Array(ref mut rhs)) => {
@@ -398,6 +399,7 @@ impl BitAndAssign<Store> for Store {
 }
 
 impl BitAndAssign<&Store> for Store {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn bitand_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
             (&mut Array(ref mut vec1), &Array(ref vec2)) => {

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -285,38 +285,6 @@ impl Store {
         }
     }
 
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `BitOrAssign::bitor_assign` ops method instead"
-    )]
-    pub fn union_with(&mut self, other: &Self) {
-        BitOrAssign::bitor_assign(self, other)
-    }
-
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `BitAndAssign::bitand_assign` ops method instead"
-    )]
-    pub fn intersect_with(&mut self, other: &Self) {
-        BitAndAssign::bitand_assign(self, other)
-    }
-
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `SubAssign::sub_assign` ops method instead"
-    )]
-    pub fn difference_with(&mut self, other: &Self) {
-        SubAssign::sub_assign(self, other)
-    }
-
-    #[deprecated(
-        since = "0.6.7",
-        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead"
-    )]
-    pub fn symmetric_difference_with(&mut self, other: &Self) {
-        BitXorAssign::bitxor_assign(self, other)
-    }
-
     pub fn len(&self) -> u64 {
         match *self {
             Array(ref vec) => vec.len() as u64,

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -16,7 +16,7 @@ impl RoaringTreemap {
     /// let rb2: RoaringTreemap = (3..5).collect();
     /// let rb3: RoaringTreemap = (1..5).collect();
     ///
-    /// rb1.union_with(&rb2);
+    /// rb1 |= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
@@ -53,7 +53,7 @@ impl RoaringTreemap {
     /// let rb2: RoaringTreemap = (3..5).collect();
     /// let rb3: RoaringTreemap = (3..4).collect();
     ///
-    /// rb1.intersect_with(&rb2);
+    /// rb1 &= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
@@ -90,7 +90,7 @@ impl RoaringTreemap {
     /// let rb2: RoaringTreemap = (3..5).collect();
     /// let rb3: RoaringTreemap = (1..3).collect();
     ///
-    /// rb1.difference_with(&rb2);
+    /// rb1 -= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
@@ -127,7 +127,7 @@ impl RoaringTreemap {
     /// let rb2: RoaringTreemap = (3..6).collect();
     /// let rb3: RoaringTreemap = (1..3).chain(4..6).collect();
     ///
-    /// rb1.symmetric_difference_with(&rb2);
+    /// rb1 ^= rb2;
     ///
     /// assert_eq!(rb1, rb3);
     /// ```

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -418,23 +418,18 @@ impl BitXor<&RoaringTreemap> for &RoaringTreemap {
 impl BitXorAssign<RoaringTreemap> for RoaringTreemap {
     /// A `symmetric difference` between two sets.
     fn bitxor_assign(&mut self, rhs: RoaringTreemap) {
-        let mut keys_to_remove: Vec<u32> = Vec::new();
         for (key, other_rb) in rhs.map {
             match self.map.entry(key) {
-                Entry::Vacant(ent) => {
-                    ent.insert(other_rb);
+                Entry::Vacant(entry) => {
+                    entry.insert(other_rb);
                 }
-                Entry::Occupied(mut ent) => {
-                    BitXorAssign::bitxor_assign(ent.get_mut(), other_rb);
-                    if ent.get().is_empty() {
-                        keys_to_remove.push(key);
+                Entry::Occupied(mut entry) => {
+                    BitXorAssign::bitxor_assign(entry.get_mut(), other_rb);
+                    if entry.get().is_empty() {
+                        entry.remove_entry();
                     }
                 }
             }
-        }
-
-        for key in keys_to_remove {
-            self.map.remove(&key);
         }
     }
 }
@@ -442,23 +437,18 @@ impl BitXorAssign<RoaringTreemap> for RoaringTreemap {
 impl BitXorAssign<&RoaringTreemap> for RoaringTreemap {
     /// A `symmetric difference` between two sets.
     fn bitxor_assign(&mut self, rhs: &RoaringTreemap) {
-        let mut keys_to_remove: Vec<u32> = Vec::new();
         for (key, other_rb) in &rhs.map {
             match self.map.entry(*key) {
-                Entry::Vacant(ent) => {
-                    ent.insert(other_rb.clone());
+                Entry::Vacant(entry) => {
+                    entry.insert(other_rb.clone());
                 }
-                Entry::Occupied(mut ent) => {
-                    BitXorAssign::bitxor_assign(ent.get_mut(), other_rb);
-                    if ent.get().is_empty() {
-                        keys_to_remove.push(*key);
+                Entry::Occupied(mut entry) => {
+                    BitXorAssign::bitxor_assign(entry.get_mut(), other_rb);
+                    if entry.get().is_empty() {
+                        entry.remove_entry();
                     }
                 }
             }
-        }
-
-        for key in keys_to_remove {
-            self.map.remove(&key);
         }
     }
 }

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -357,18 +357,16 @@ impl SubAssign<RoaringTreemap> for RoaringTreemap {
 impl SubAssign<&RoaringTreemap> for RoaringTreemap {
     /// A `difference` between two sets.
     fn sub_assign(&mut self, rhs: &RoaringTreemap) {
-        let mut keys_to_remove: Vec<u32> = Vec::new();
-        for (key, self_rb) in &mut self.map {
-            if let Some(other_rb) = rhs.map.get(key) {
-                SubAssign::sub_assign(self_rb, other_rb);
-                if self_rb.is_empty() {
-                    keys_to_remove.push(*key);
+        for (key, rhs_rb) in &rhs.map {
+            match self.map.entry(*key) {
+                Entry::Vacant(_entry) => (),
+                Entry::Occupied(mut entry) => {
+                    SubAssign::sub_assign(entry.get_mut(), rhs_rb);
+                    if entry.get().is_empty() {
+                        entry.remove_entry();
+                    }
                 }
             }
-        }
-
-        for key in keys_to_remove {
-            self.map.remove(&key);
         }
     }
 }

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -36,7 +36,7 @@ impl RoaringTreemap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitOrAssign::bitor_assign` ops method instead"
+        note = "Please use the `BitOrAssign::bitor_assign` (`|=`) ops method instead"
     )]
     pub fn union_with(&mut self, other: &RoaringTreemap) {
         BitOrAssign::bitor_assign(self, other)
@@ -73,7 +73,7 @@ impl RoaringTreemap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitAndAssign::bitand_assign` ops method instead"
+        note = "Please use the `BitAndAssign::bitand_assign` (`&=`) ops method instead"
     )]
     pub fn intersect_with(&mut self, other: &RoaringTreemap) {
         BitAndAssign::bitand_assign(self, other)
@@ -110,7 +110,7 @@ impl RoaringTreemap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `SubAssign::sub_assign` ops method instead"
+        note = "Please use the `SubAssign::sub_assign` (`-=`) ops method instead"
     )]
     pub fn difference_with(&mut self, other: &RoaringTreemap) {
         SubAssign::sub_assign(self, other)
@@ -147,7 +147,7 @@ impl RoaringTreemap {
     /// ```
     #[deprecated(
         since = "0.6.7",
-        note = "Please use the `BitXorAssign::bitxor_assign` ops method instead"
+        note = "Please use the `BitXorAssign::bitxor_assign` (`^=`) ops method instead"
     )]
     pub fn symmetric_difference_with(&mut self, other: &RoaringTreemap) {
         BitXorAssign::bitxor_assign(self, other)
@@ -157,7 +157,7 @@ impl RoaringTreemap {
 impl BitOr<RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(mut self, rhs: RoaringTreemap) -> RoaringTreemap {
         BitOrAssign::bitor_assign(&mut self, rhs);
         self
@@ -167,7 +167,7 @@ impl BitOr<RoaringTreemap> for RoaringTreemap {
 impl BitOr<&RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(mut self, rhs: &RoaringTreemap) -> RoaringTreemap {
         BitOrAssign::bitor_assign(&mut self, rhs);
         self
@@ -177,7 +177,7 @@ impl BitOr<&RoaringTreemap> for RoaringTreemap {
 impl BitOr<RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(self, rhs: RoaringTreemap) -> RoaringTreemap {
         BitOr::bitor(rhs, self)
     }
@@ -186,7 +186,7 @@ impl BitOr<RoaringTreemap> for &RoaringTreemap {
 impl BitOr<&RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor(self, rhs: &RoaringTreemap) -> RoaringTreemap {
         if self.len() <= rhs.len() {
             BitOr::bitor(rhs.clone(), self)
@@ -197,7 +197,7 @@ impl BitOr<&RoaringTreemap> for &RoaringTreemap {
 }
 
 impl BitOrAssign<RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor_assign(&mut self, mut rhs: RoaringTreemap) {
         // We make sure that we apply the union operation on the biggest map.
         if self.len() < rhs.len() {
@@ -218,7 +218,7 @@ impl BitOrAssign<RoaringTreemap> for RoaringTreemap {
 }
 
 impl BitOrAssign<&RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to an `union` between both maps.
+    /// An `union` between two sets.
     fn bitor_assign(&mut self, rhs: &RoaringTreemap) {
         for (key, other_rb) in &rhs.map {
             match self.map.entry(*key) {
@@ -236,7 +236,7 @@ impl BitOrAssign<&RoaringTreemap> for RoaringTreemap {
 impl BitAnd<RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(mut self, rhs: RoaringTreemap) -> RoaringTreemap {
         BitAndAssign::bitand_assign(&mut self, rhs);
         self
@@ -246,7 +246,7 @@ impl BitAnd<RoaringTreemap> for RoaringTreemap {
 impl BitAnd<&RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(mut self, rhs: &RoaringTreemap) -> RoaringTreemap {
         BitAndAssign::bitand_assign(&mut self, rhs);
         self
@@ -256,7 +256,7 @@ impl BitAnd<&RoaringTreemap> for RoaringTreemap {
 impl BitAnd<RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(self, rhs: RoaringTreemap) -> RoaringTreemap {
         BitAnd::bitand(rhs, self)
     }
@@ -265,7 +265,7 @@ impl BitAnd<RoaringTreemap> for &RoaringTreemap {
 impl BitAnd<&RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand(self, rhs: &RoaringTreemap) -> RoaringTreemap {
         if rhs.len() < self.len() {
             BitAnd::bitand(self.clone(), rhs)
@@ -276,7 +276,7 @@ impl BitAnd<&RoaringTreemap> for &RoaringTreemap {
 }
 
 impl BitAndAssign<RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand_assign(&mut self, mut rhs: RoaringTreemap) {
         // We make sure that we apply the intersection operation on the smallest map.
         if rhs.len() < self.len() {
@@ -288,7 +288,7 @@ impl BitAndAssign<RoaringTreemap> for RoaringTreemap {
 }
 
 impl BitAndAssign<&RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to an `intersection` between both maps.
+    /// An `intersection` between two sets.
     fn bitand_assign(&mut self, rhs: &RoaringTreemap) {
         let mut keys_to_remove: Vec<u32> = Vec::new();
         for (key, self_rb) in &mut self.map {
@@ -312,7 +312,7 @@ impl BitAndAssign<&RoaringTreemap> for RoaringTreemap {
 impl Sub<RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(mut self, rhs: RoaringTreemap) -> RoaringTreemap {
         SubAssign::sub_assign(&mut self, rhs);
         self
@@ -322,7 +322,7 @@ impl Sub<RoaringTreemap> for RoaringTreemap {
 impl Sub<&RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(mut self, rhs: &RoaringTreemap) -> RoaringTreemap {
         SubAssign::sub_assign(&mut self, rhs);
         self
@@ -332,7 +332,7 @@ impl Sub<&RoaringTreemap> for RoaringTreemap {
 impl Sub<RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(self, rhs: RoaringTreemap) -> RoaringTreemap {
         Sub::sub(self.clone(), rhs)
     }
@@ -341,21 +341,21 @@ impl Sub<RoaringTreemap> for &RoaringTreemap {
 impl Sub<&RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub(self, rhs: &RoaringTreemap) -> RoaringTreemap {
         Sub::sub(self.clone(), rhs)
     }
 }
 
 impl SubAssign<RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub_assign(&mut self, rhs: RoaringTreemap) {
         SubAssign::sub_assign(self, &rhs)
     }
 }
 
 impl SubAssign<&RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to a `difference` between both maps.
+    /// A `difference` between two sets.
     fn sub_assign(&mut self, rhs: &RoaringTreemap) {
         let mut keys_to_remove: Vec<u32> = Vec::new();
         for (key, self_rb) in &mut self.map {
@@ -376,7 +376,7 @@ impl SubAssign<&RoaringTreemap> for RoaringTreemap {
 impl BitXor<RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(mut self, rhs: RoaringTreemap) -> RoaringTreemap {
         BitXorAssign::bitxor_assign(&mut self, rhs);
         self
@@ -386,7 +386,7 @@ impl BitXor<RoaringTreemap> for RoaringTreemap {
 impl BitXor<&RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(mut self, rhs: &RoaringTreemap) -> RoaringTreemap {
         BitXorAssign::bitxor_assign(&mut self, rhs);
         self
@@ -396,7 +396,7 @@ impl BitXor<&RoaringTreemap> for RoaringTreemap {
 impl BitXor<RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(self, rhs: RoaringTreemap) -> RoaringTreemap {
         BitXor::bitxor(rhs, self)
     }
@@ -405,7 +405,7 @@ impl BitXor<RoaringTreemap> for &RoaringTreemap {
 impl BitXor<&RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor(self, rhs: &RoaringTreemap) -> RoaringTreemap {
         if self.len() < rhs.len() {
             BitXor::bitxor(self, rhs.clone())
@@ -416,7 +416,7 @@ impl BitXor<&RoaringTreemap> for &RoaringTreemap {
 }
 
 impl BitXorAssign<RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor_assign(&mut self, rhs: RoaringTreemap) {
         let mut keys_to_remove: Vec<u32> = Vec::new();
         for (key, other_rb) in rhs.map {
@@ -440,7 +440,7 @@ impl BitXorAssign<RoaringTreemap> for RoaringTreemap {
 }
 
 impl BitXorAssign<&RoaringTreemap> for RoaringTreemap {
-    /// This is equivalent to a `symmetric difference` between both maps.
+    /// A `symmetric difference` between two sets.
     fn bitxor_assign(&mut self, rhs: &RoaringTreemap) {
         let mut keys_to_remove: Vec<u32> = Vec::new();
         for (key, other_rb) in &rhs.map {

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -108,20 +108,12 @@ impl RoaringTreemap {
     ///
     /// assert_eq!(rb1, rb3);
     /// ```
+    #[deprecated(
+        since = "0.6.7",
+        note = "Please use the `SubAssign::sub_assign` ops method instead"
+    )]
     pub fn difference_with(&mut self, other: &RoaringTreemap) {
-        let mut keys_to_remove: Vec<u32> = Vec::new();
-        for (key, self_rb) in &mut self.map {
-            if let Some(other_rb) = other.map.get(key) {
-                self_rb.difference_with(other_rb);
-                if self_rb.is_empty() {
-                    keys_to_remove.push(*key);
-                }
-            }
-        }
-
-        for key in keys_to_remove {
-            self.map.remove(&key);
-        }
+        SubAssign::sub_assign(self, other)
     }
 
     /// Replaces this bitmap with one that is equivalent to `self XOR other`.
@@ -333,46 +325,64 @@ impl BitAndAssign<&RoaringTreemap> for RoaringTreemap {
 impl Sub<RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
+    /// This is equivalent to a `difference` between both maps.
     fn sub(mut self, rhs: RoaringTreemap) -> RoaringTreemap {
-        self.difference_with(&rhs);
+        SubAssign::sub_assign(&mut self, rhs);
         self
     }
 }
 
-impl<'a> Sub<&'a RoaringTreemap> for RoaringTreemap {
+impl Sub<&RoaringTreemap> for RoaringTreemap {
     type Output = RoaringTreemap;
 
-    fn sub(mut self, rhs: &'a RoaringTreemap) -> RoaringTreemap {
-        self.difference_with(rhs);
+    /// This is equivalent to a `difference` between both maps.
+    fn sub(mut self, rhs: &RoaringTreemap) -> RoaringTreemap {
+        SubAssign::sub_assign(&mut self, rhs);
         self
     }
 }
 
-impl<'a> Sub<RoaringTreemap> for &'a RoaringTreemap {
+impl Sub<RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
+    /// This is equivalent to a `difference` between both maps.
     fn sub(self, rhs: RoaringTreemap) -> RoaringTreemap {
-        self.clone() - rhs
+        Sub::sub(self.clone(), rhs)
     }
 }
 
-impl<'a, 'b> Sub<&'a RoaringTreemap> for &'b RoaringTreemap {
+impl Sub<&RoaringTreemap> for &RoaringTreemap {
     type Output = RoaringTreemap;
 
-    fn sub(self, rhs: &'a RoaringTreemap) -> RoaringTreemap {
-        self.clone() - rhs
+    /// This is equivalent to a `difference` between both maps.
+    fn sub(self, rhs: &RoaringTreemap) -> RoaringTreemap {
+        Sub::sub(self.clone(), rhs)
     }
 }
 
 impl SubAssign<RoaringTreemap> for RoaringTreemap {
+    /// This is equivalent to a `difference` between both maps.
     fn sub_assign(&mut self, rhs: RoaringTreemap) {
-        self.difference_with(&rhs)
+        SubAssign::sub_assign(self, &rhs)
     }
 }
 
-impl<'a> SubAssign<&'a RoaringTreemap> for RoaringTreemap {
-    fn sub_assign(&mut self, rhs: &'a RoaringTreemap) {
-        self.difference_with(rhs)
+impl SubAssign<&RoaringTreemap> for RoaringTreemap {
+    /// This is equivalent to a `difference` between both maps.
+    fn sub_assign(&mut self, rhs: &RoaringTreemap) {
+        let mut keys_to_remove: Vec<u32> = Vec::new();
+        for (key, self_rb) in &mut self.map {
+            if let Some(other_rb) = rhs.map.get(key) {
+                SubAssign::sub_assign(self_rb, other_rb);
+                if self_rb.is_empty() {
+                    keys_to_remove.push(*key);
+                }
+            }
+        }
+
+        for key in keys_to_remove {
+            self.map.remove(&key);
+        }
     }
 }
 

--- a/tests/difference_with.rs
+++ b/tests/difference_with.rs
@@ -7,7 +7,7 @@ fn array() {
     let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
     let bitmap3 = (0..1000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -17,7 +17,7 @@ fn no_difference() {
     let mut bitmap1 = (1..3).collect::<RoaringBitmap>();
     let bitmap2 = (1..3).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, RoaringBitmap::new());
 }
@@ -28,7 +28,7 @@ fn array_and_bitmap() {
     let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
     let bitmap3 = (0..1000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -39,7 +39,7 @@ fn bitmap_to_bitmap() {
     let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
     let bitmap3 = (0..6000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -50,7 +50,7 @@ fn bitmap_to_array() {
     let bitmap2 = (3000..9000).collect::<RoaringBitmap>();
     let bitmap3 = (0..3000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -61,7 +61,7 @@ fn bitmap_and_array_to_bitmap() {
     let bitmap2 = (9000..12000).collect::<RoaringBitmap>();
     let bitmap3 = (0..9000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -72,7 +72,7 @@ fn bitmap_and_array_to_array() {
     let bitmap2 = (3000..6000).collect::<RoaringBitmap>();
     let bitmap3 = (0..3000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -91,7 +91,7 @@ fn arrays() {
         .chain(1_000_000..1_001_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -108,7 +108,7 @@ fn arrays_removing_one_whole_container() {
         .collect::<RoaringBitmap>();
     let bitmap3 = (1_000_000..1_001_000).collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -127,7 +127,7 @@ fn bitmaps() {
         .chain(1_000_000..1_006_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/intersect_with.rs
+++ b/tests/intersect_with.rs
@@ -7,7 +7,7 @@ fn array() {
     let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
     let bitmap3 = (1000..2000).collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -17,7 +17,7 @@ fn no_intersection() {
     let mut bitmap1 = (0..2).collect::<RoaringBitmap>();
     let bitmap2 = (3..4).collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, RoaringBitmap::new());
 }
@@ -28,7 +28,7 @@ fn array_and_bitmap() {
     let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
     let bitmap3 = (1000..2000).collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -39,7 +39,7 @@ fn bitmap_to_bitmap() {
     let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
     let bitmap3 = (6000..12000).collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -50,7 +50,7 @@ fn bitmap_to_array() {
     let bitmap2 = (3000..9000).collect::<RoaringBitmap>();
     let bitmap3 = (3000..6000).collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -61,7 +61,7 @@ fn bitmap_and_array() {
     let bitmap2 = (7000..9000).collect::<RoaringBitmap>();
     let bitmap3 = (7000..9000).collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -80,7 +80,7 @@ fn arrays() {
         .chain(1_001_000..1_002_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -99,7 +99,7 @@ fn bitmaps() {
         .chain(1_006_000..1_012_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/is_disjoint.rs
+++ b/tests/is_disjoint.rs
@@ -5,28 +5,28 @@ use roaring::RoaringBitmap;
 fn array() {
     let bitmap1 = (0..2000).collect::<RoaringBitmap>();
     let bitmap2 = (4000..6000).collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn array_not() {
     let bitmap1 = (0..4000).collect::<RoaringBitmap>();
     let bitmap2 = (2000..6000).collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn bitmap() {
     let bitmap1 = (0..6000).collect::<RoaringBitmap>();
     let bitmap2 = (10000..16000).collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn bitmap_not() {
     let bitmap1 = (0..10000).collect::<RoaringBitmap>();
     let bitmap2 = (5000..15000).collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn arrays() {
     let bitmap2 = (100_000..102_000)
         .chain(1_100_000..1_102_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn arrays_not() {
     let bitmap2 = (100_000..102_000)
         .chain(1_001_000..1_003_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn bitmaps() {
     let bitmap2 = (100_000..106_000)
         .chain(1_100_000..1_106_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
@@ -74,5 +74,5 @@ fn bitmaps_not() {
     let bitmap2 = (100_000..106_000)
         .chain(1_004_000..1_008_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }

--- a/tests/is_subset.rs
+++ b/tests/is_subset.rs
@@ -5,49 +5,49 @@ use roaring::RoaringBitmap;
 fn array_not() {
     let sup = (0..2000).collect::<RoaringBitmap>();
     let sub = (1000..3000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), false);
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn array() {
     let sup = (0..4000).collect::<RoaringBitmap>();
     let sub = (2000..3000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), true);
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
 fn array_bitmap_not() {
     let sup = (0..2000).collect::<RoaringBitmap>();
     let sub = (1000..15000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), false);
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap_not() {
     let sup = (0..6000).collect::<RoaringBitmap>();
     let sub = (4000..10000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), false);
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap() {
     let sup = (0..20000).collect::<RoaringBitmap>();
     let sub = (5000..15000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), true);
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap_array_not() {
     let sup = (0..20000).collect::<RoaringBitmap>();
     let sub = (19000..21000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), false);
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap_array() {
     let sup = (0..20000).collect::<RoaringBitmap>();
     let sub = (18000..20000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), true);
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
@@ -58,14 +58,14 @@ fn arrays_not() {
     let sub = (100_000..102_000)
         .chain(1_100_000..1_102_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), false);
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn arrays() {
     let sup = (0..3000).chain(100_000..103_000).collect::<RoaringBitmap>();
     let sub = (0..2000).chain(100_000..102_000).collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), true);
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn bitmaps_not() {
     let sub = (100_000..106_000)
         .chain(1_100_000..1_106_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), false);
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
@@ -88,5 +88,5 @@ fn bitmaps() {
     let sub = (0..10_000)
         .chain(500_000..510_000)
         .collect::<RoaringBitmap>();
-    assert_eq!(sub.is_subset(&sup), true);
+    assert!(sub.is_subset(&sup));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,32 +5,32 @@ use roaring::RoaringBitmap;
 fn smoke() {
     let mut bitmap = RoaringBitmap::new();
     assert_eq!(bitmap.len(), 0);
-    assert_eq!(bitmap.is_empty(), true);
+    assert!(bitmap.is_empty());
     bitmap.remove(0);
     assert_eq!(bitmap.len(), 0);
-    assert_eq!(bitmap.is_empty(), true);
+    assert!(bitmap.is_empty());
     bitmap.insert(1);
-    assert_eq!(bitmap.contains(1), true);
+    assert!(bitmap.contains(1));
     assert_eq!(bitmap.len(), 1);
-    assert_eq!(bitmap.is_empty(), false);
+    assert!(!bitmap.is_empty());
     bitmap.insert(u32::max_value() - 2);
-    assert_eq!(bitmap.contains(u32::max_value() - 2), true);
+    assert!(bitmap.contains(u32::max_value() - 2));
     assert_eq!(bitmap.len(), 2);
     bitmap.insert(u32::max_value());
-    assert_eq!(bitmap.contains(u32::max_value()), true);
+    assert!(bitmap.contains(u32::max_value()));
     assert_eq!(bitmap.len(), 3);
     bitmap.insert(2);
-    assert_eq!(bitmap.contains(2), true);
+    assert!(bitmap.contains(2));
     assert_eq!(bitmap.len(), 4);
     bitmap.remove(2);
-    assert_eq!(bitmap.contains(2), false);
+    assert!(!bitmap.contains(2));
     assert_eq!(bitmap.len(), 3);
-    assert_eq!(bitmap.contains(0), false);
-    assert_eq!(bitmap.contains(1), true);
-    assert_eq!(bitmap.contains(100), false);
-    assert_eq!(bitmap.contains(u32::max_value() - 2), true);
-    assert_eq!(bitmap.contains(u32::max_value() - 1), false);
-    assert_eq!(bitmap.contains(u32::max_value()), true);
+    assert!(!bitmap.contains(0));
+    assert!(bitmap.contains(1));
+    assert!(!bitmap.contains(100));
+    assert!(bitmap.contains(u32::max_value() - 2));
+    assert!(!bitmap.contains(u32::max_value() - 1));
+    assert!(bitmap.contains(u32::max_value()));
 }
 
 #[test]
@@ -118,9 +118,9 @@ fn to_bitmap() {
     let bitmap = (0..5000).collect::<RoaringBitmap>();
     assert_eq!(bitmap.len(), 5000);
     for i in 1..5000 {
-        assert_eq!(bitmap.contains(i), true);
+        assert!(bitmap.contains(i));
     }
-    assert_eq!(bitmap.contains(5001), false);
+    assert!(!bitmap.contains(5001));
 }
 
 #[test]
@@ -131,9 +131,9 @@ fn to_array() {
     }
     assert_eq!(bitmap.len(), 3000);
     for i in 0..3000 {
-        assert_eq!(bitmap.contains(i), true);
+        assert!(bitmap.contains(i));
     }
     for i in 3000..5000 {
-        assert_eq!(bitmap.contains(i), false);
+        assert!(!bitmap.contains(i));
     }
 }

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -83,7 +83,7 @@ fn test_bitmap_high16bits() {
     bitmap.serialize_into(&mut buffer).unwrap();
 
     let new = RoaringBitmap::deserialize_from(&buffer[..]);
-    assert_eq!(true, new.is_ok());
+    assert!(new.is_ok());
     assert_eq!(bitmap, new.unwrap());
 }
 

--- a/tests/symmetric_difference_with.rs
+++ b/tests/symmetric_difference_with.rs
@@ -7,7 +7,7 @@ fn array() {
     let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
     let bitmap3 = (0..1000).chain(2000..3000).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -17,7 +17,7 @@ fn no_symmetric_difference() {
     let mut bitmap1 = (0..2).collect::<RoaringBitmap>();
     let bitmap2 = (0..2).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, RoaringBitmap::new());
 }
@@ -28,7 +28,7 @@ fn array_and_bitmap() {
     let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
     let bitmap3 = (0..1000).chain(2000..8000).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -39,7 +39,7 @@ fn bitmap_to_bitmap() {
     let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
     let bitmap3 = (0..6000).chain(12000..18000).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -50,7 +50,7 @@ fn bitmap_to_array() {
     let bitmap2 = (2000..7000).collect::<RoaringBitmap>();
     let bitmap3 = (0..2000).chain(6000..7000).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -61,7 +61,7 @@ fn bitmap_and_array_to_bitmap() {
     let bitmap2 = (11000..14000).collect::<RoaringBitmap>();
     let bitmap3 = (0..11000).chain(12000..14000).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -72,7 +72,7 @@ fn bitmap_and_array_to_array() {
     let bitmap2 = (3000..7000).collect::<RoaringBitmap>();
     let bitmap3 = (0..3000).chain(6000..7000).collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -95,7 +95,7 @@ fn arrays() {
         .chain(3_000_000..3_001_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -118,7 +118,7 @@ fn bitmaps() {
         .chain(3_000_000..3_010_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/treemap_clone.rs
+++ b/tests/treemap_clone.rs
@@ -1,11 +1,9 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
-    let original = RoaringTreemap::from_iter(0..2000);
+    let original = (0..2000).collect::<RoaringTreemap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -13,7 +11,7 @@ fn array() {
 
 #[test]
 fn bitmap() {
-    let original = RoaringTreemap::from_iter(0..6000);
+    let original = (0..6000).collect::<RoaringTreemap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -21,11 +19,10 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
+    let original = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -33,11 +30,10 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let original = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
     let clone = original.clone();
 
     assert_eq!(clone, original);

--- a/tests/treemap_difference_with.rs
+++ b/tests/treemap_difference_with.rs
@@ -9,7 +9,7 @@ fn array() {
     let bitmap2 = RoaringTreemap::from_iter(1000..3000);
     let bitmap3 = RoaringTreemap::from_iter(0..1000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -19,7 +19,7 @@ fn no_difference() {
     let mut bitmap1 = RoaringTreemap::from_iter(1..3);
     let bitmap2 = RoaringTreemap::from_iter(1..3);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, RoaringTreemap::new());
 }
@@ -30,7 +30,7 @@ fn array_and_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(1000..8000);
     let bitmap3 = RoaringTreemap::from_iter(0..1000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -41,7 +41,7 @@ fn bitmap_to_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(6000..18000);
     let bitmap3 = RoaringTreemap::from_iter(0..6000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -52,7 +52,7 @@ fn bitmap_to_array() {
     let bitmap2 = RoaringTreemap::from_iter(3000..9000);
     let bitmap3 = RoaringTreemap::from_iter(0..3000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -63,7 +63,7 @@ fn bitmap_and_array_to_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(9000..12000);
     let bitmap3 = RoaringTreemap::from_iter(0..9000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -74,7 +74,7 @@ fn bitmap_and_array_to_array() {
     let bitmap2 = RoaringTreemap::from_iter(3000..6000);
     let bitmap3 = RoaringTreemap::from_iter(0..3000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -93,7 +93,7 @@ fn arrays() {
     );
     let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(1_000_000..1_001_000));
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -112,7 +112,7 @@ fn arrays_removing_one_whole_container() {
     );
     let bitmap3 = RoaringTreemap::from_iter(1_000_000..1_001_000);
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -131,7 +131,7 @@ fn bitmaps() {
     );
     let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(1_000_000..1_006_000));
 
-    bitmap1.difference_with(&bitmap2);
+    bitmap1 -= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/treemap_difference_with.rs
+++ b/tests/treemap_difference_with.rs
@@ -1,13 +1,11 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..3000);
-    let bitmap3 = RoaringTreemap::from_iter(0..1000);
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..3000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..1000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -16,8 +14,8 @@ fn array() {
 
 #[test]
 fn no_difference() {
-    let mut bitmap1 = RoaringTreemap::from_iter(1..3);
-    let bitmap2 = RoaringTreemap::from_iter(1..3);
+    let mut bitmap1 = (1..3).collect::<RoaringTreemap>();
+    let bitmap2 = (1..3).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -26,9 +24,9 @@ fn no_difference() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..8000);
-    let bitmap3 = RoaringTreemap::from_iter(0..1000);
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..8000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..1000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -37,9 +35,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap_to_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(6000..18000);
-    let bitmap3 = RoaringTreemap::from_iter(0..6000);
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (6000..18000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..6000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -48,9 +46,9 @@ fn bitmap_to_bitmap() {
 
 #[test]
 fn bitmap_to_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..6000);
-    let bitmap2 = RoaringTreemap::from_iter(3000..9000);
-    let bitmap3 = RoaringTreemap::from_iter(0..3000);
+    let mut bitmap1 = (0..6000).collect::<RoaringTreemap>();
+    let bitmap2 = (3000..9000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..3000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -59,9 +57,9 @@ fn bitmap_to_array() {
 
 #[test]
 fn bitmap_and_array_to_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(9000..12000);
-    let bitmap3 = RoaringTreemap::from_iter(0..9000);
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (9000..12000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..9000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -70,9 +68,9 @@ fn bitmap_and_array_to_bitmap() {
 
 #[test]
 fn bitmap_and_array_to_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..6000);
-    let bitmap2 = RoaringTreemap::from_iter(3000..6000);
-    let bitmap3 = RoaringTreemap::from_iter(0..3000);
+    let mut bitmap1 = (0..6000).collect::<RoaringTreemap>();
+    let bitmap2 = (3000..6000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..3000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -81,17 +79,15 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(1_000_000..1_001_000));
+    let mut bitmap1 = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((0..1000).chain(1_000_000..1_001_000)).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -100,17 +96,15 @@ fn arrays() {
 
 #[test]
 fn arrays_removing_one_whole_container() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (0..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter(1_000_000..1_001_000);
+    let mut bitmap1 = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((0..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = (1_000_000..1_001_000).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 
@@ -119,17 +113,15 @@ fn arrays_removing_one_whole_container() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (3000..9000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(1_000_000..1_006_000));
+    let mut bitmap1 = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((3000..9000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((0..3000).chain(1_000_000..1_006_000)).collect::<RoaringTreemap>();
 
     bitmap1 -= bitmap2;
 

--- a/tests/treemap_intersect_with.rs
+++ b/tests/treemap_intersect_with.rs
@@ -9,7 +9,7 @@ fn array() {
     let bitmap2 = RoaringTreemap::from_iter(1000..3000);
     let bitmap3 = RoaringTreemap::from_iter(1000..2000);
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -19,7 +19,7 @@ fn no_intersection() {
     let mut bitmap1 = RoaringTreemap::from_iter(0..2);
     let bitmap2 = RoaringTreemap::from_iter(3..4);
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, RoaringTreemap::new());
 }
@@ -30,7 +30,7 @@ fn array_and_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(1000..8000);
     let bitmap3 = RoaringTreemap::from_iter(1000..2000);
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -41,7 +41,7 @@ fn bitmap_to_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(6000..18000);
     let bitmap3 = RoaringTreemap::from_iter(6000..12000);
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -52,7 +52,7 @@ fn bitmap_to_array() {
     let bitmap2 = RoaringTreemap::from_iter(3000..9000);
     let bitmap3 = RoaringTreemap::from_iter(3000..6000);
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -63,7 +63,7 @@ fn bitmap_and_array() {
     let bitmap2 = RoaringTreemap::from_iter(7000..9000);
     let bitmap3 = RoaringTreemap::from_iter(7000..9000);
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -82,7 +82,7 @@ fn arrays() {
     );
     let bitmap3 = RoaringTreemap::from_iter((1000..2000).chain(1_001_000..1_002_000));
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -101,7 +101,7 @@ fn bitmaps() {
     );
     let bitmap3 = RoaringTreemap::from_iter((3000..6000).chain(1_006_000..1_012_000));
 
-    bitmap1.intersect_with(&bitmap2);
+    bitmap1 &= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/treemap_intersect_with.rs
+++ b/tests/treemap_intersect_with.rs
@@ -1,13 +1,11 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..3000);
-    let bitmap3 = RoaringTreemap::from_iter(1000..2000);
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..3000).collect::<RoaringTreemap>();
+    let bitmap3 = (1000..2000).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -16,8 +14,8 @@ fn array() {
 
 #[test]
 fn no_intersection() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2);
-    let bitmap2 = RoaringTreemap::from_iter(3..4);
+    let mut bitmap1 = (0..2).collect::<RoaringTreemap>();
+    let bitmap2 = (3..4).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -26,9 +24,9 @@ fn no_intersection() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..8000);
-    let bitmap3 = RoaringTreemap::from_iter(1000..2000);
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..8000).collect::<RoaringTreemap>();
+    let bitmap3 = (1000..2000).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -37,9 +35,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap_to_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(6000..18000);
-    let bitmap3 = RoaringTreemap::from_iter(6000..12000);
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (6000..18000).collect::<RoaringTreemap>();
+    let bitmap3 = (6000..12000).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -48,9 +46,9 @@ fn bitmap_to_bitmap() {
 
 #[test]
 fn bitmap_to_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..6000);
-    let bitmap2 = RoaringTreemap::from_iter(3000..9000);
-    let bitmap3 = RoaringTreemap::from_iter(3000..6000);
+    let mut bitmap1 = (0..6000).collect::<RoaringTreemap>();
+    let bitmap2 = (3000..9000).collect::<RoaringTreemap>();
+    let bitmap3 = (3000..6000).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -59,9 +57,9 @@ fn bitmap_to_array() {
 
 #[test]
 fn bitmap_and_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(7000..9000);
-    let bitmap3 = RoaringTreemap::from_iter(7000..9000);
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (7000..9000).collect::<RoaringTreemap>();
+    let bitmap3 = (7000..9000).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -70,17 +68,15 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(3_000_000..3_001_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter((1000..2000).chain(1_001_000..1_002_000));
+    let mut bitmap1 = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(3_000_000..3_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((1000..2000).chain(1_001_000..1_002_000)).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 
@@ -89,17 +85,15 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(3_000_000..3_010_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (3000..9000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter((3000..6000).chain(1_006_000..1_012_000));
+    let mut bitmap1 = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(3_000_000..3_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((3000..9000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((3000..6000).chain(1_006_000..1_012_000)).collect::<RoaringTreemap>();
 
     bitmap1 &= bitmap2;
 

--- a/tests/treemap_is_disjoint.rs
+++ b/tests/treemap_is_disjoint.rs
@@ -1,76 +1,70 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
-    let bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(4000..6000);
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    let bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (4000..6000).collect::<RoaringTreemap>();
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn array_not() {
-    let bitmap1 = RoaringTreemap::from_iter(0..4000);
-    let bitmap2 = RoaringTreemap::from_iter(2000..6000);
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    let bitmap1 = (0..4000).collect::<RoaringTreemap>();
+    let bitmap2 = (2000..6000).collect::<RoaringTreemap>();
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn bitmap() {
-    let bitmap1 = RoaringTreemap::from_iter(0..6000);
-    let bitmap2 = RoaringTreemap::from_iter(10000..16000);
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    let bitmap1 = (0..6000).collect::<RoaringTreemap>();
+    let bitmap2 = (10000..16000).collect::<RoaringTreemap>();
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn bitmap_not() {
-    let bitmap1 = RoaringTreemap::from_iter(0..10000);
-    let bitmap2 = RoaringTreemap::from_iter(5000..15000);
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    let bitmap1 = (0..10000).collect::<RoaringTreemap>();
+    let bitmap2 = (5000..15000).collect::<RoaringTreemap>();
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn arrays() {
-    let bitmap1 = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_002_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter((100_000..102_000).chain(1_100_000..1_102_000));
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    let bitmap1 = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_002_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((100_000..102_000).chain(1_100_000..1_102_000)).collect::<RoaringTreemap>();
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn arrays_not() {
-    let bitmap1 = RoaringTreemap::from_iter(
-        (0..2_000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_002_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter((100_000..102_000).chain(1_001_000..1_003_000));
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    let bitmap1 = ((0..2_000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_002_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((100_000..102_000).chain(1_001_000..1_003_000)).collect::<RoaringTreemap>();
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn bitmaps() {
-    let bitmap1 = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_006_000)
-            .chain(2_000_000..2_006_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
+    let bitmap1 = ((0..6000)
+        .chain(1_000_000..1_006_000)
+        .chain(2_000_000..2_006_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((100_000..106_000).chain(1_100_000..1_106_000)).collect::<RoaringTreemap>();
+    assert!(bitmap1.is_disjoint(&bitmap2));
 }
 
 #[test]
 fn bitmaps_not() {
-    let bitmap1 = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_006_000)
-            .chain(2_000_000..2_006_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter((100_000..106_000).chain(1_004_000..1_008_000));
-    assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
+    let bitmap1 = ((0..6000)
+        .chain(1_000_000..1_006_000)
+        .chain(2_000_000..2_006_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((100_000..106_000).chain(1_004_000..1_008_000)).collect::<RoaringTreemap>();
+    assert!(!bitmap1.is_disjoint(&bitmap2));
 }

--- a/tests/treemap_is_subset.rs
+++ b/tests/treemap_is_subset.rs
@@ -1,85 +1,82 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array_not() {
-    let sup = RoaringTreemap::from_iter(0..2000);
-    let sub = RoaringTreemap::from_iter(1000..3000);
-    assert_eq!(sub.is_subset(&sup), false);
+    let sup = (0..2000).collect::<RoaringTreemap>();
+    let sub = (1000..3000).collect::<RoaringTreemap>();
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn array() {
-    let sup = RoaringTreemap::from_iter(0..4000);
-    let sub = RoaringTreemap::from_iter(2000..3000);
-    assert_eq!(sub.is_subset(&sup), true);
+    let sup = (0..4000).collect::<RoaringTreemap>();
+    let sub = (2000..3000).collect::<RoaringTreemap>();
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
 fn array_bitmap_not() {
-    let sup = RoaringTreemap::from_iter(0..2000);
-    let sub = RoaringTreemap::from_iter(1000..15000);
-    assert_eq!(sub.is_subset(&sup), false);
+    let sup = (0..2000).collect::<RoaringTreemap>();
+    let sub = (1000..15000).collect::<RoaringTreemap>();
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap_not() {
-    let sup = RoaringTreemap::from_iter(0..6000);
-    let sub = RoaringTreemap::from_iter(4000..10000);
-    assert_eq!(sub.is_subset(&sup), false);
+    let sup = (0..6000).collect::<RoaringTreemap>();
+    let sub = (4000..10000).collect::<RoaringTreemap>();
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap() {
-    let sup = RoaringTreemap::from_iter(0..20000);
-    let sub = RoaringTreemap::from_iter(5000..15000);
-    assert_eq!(sub.is_subset(&sup), true);
+    let sup = (0..20000).collect::<RoaringTreemap>();
+    let sub = (5000..15000).collect::<RoaringTreemap>();
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap_array_not() {
-    let sup = RoaringTreemap::from_iter(0..20000);
-    let sub = RoaringTreemap::from_iter(19000..21000);
-    assert_eq!(sub.is_subset(&sup), false);
+    let sup = (0..20000).collect::<RoaringTreemap>();
+    let sub = (19000..21000).collect::<RoaringTreemap>();
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmap_array() {
-    let sup = RoaringTreemap::from_iter(0..20000);
-    let sub = RoaringTreemap::from_iter(18000..20000);
-    assert_eq!(sub.is_subset(&sup), true);
+    let sup = (0..20000).collect::<RoaringTreemap>();
+    let sub = (18000..20000).collect::<RoaringTreemap>();
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
 fn arrays_not() {
-    let sup = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000));
-    let sub = RoaringTreemap::from_iter((100_000..102_000).chain(1_100_000..1_102_000));
-    assert_eq!(sub.is_subset(&sup), false);
+    let sup = ((0..2000).chain(1_000_000..1_002_000)).collect::<RoaringTreemap>();
+    let sub = ((100_000..102_000).chain(1_100_000..1_102_000)).collect::<RoaringTreemap>();
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn arrays() {
-    let sup = RoaringTreemap::from_iter((0..3000).chain(100_000..103_000));
-    let sub = RoaringTreemap::from_iter((0..2000).chain(100_000..102_000));
-    assert_eq!(sub.is_subset(&sup), true);
+    let sup = ((0..3000).chain(100_000..103_000)).collect::<RoaringTreemap>();
+    let sub = ((0..2000).chain(100_000..102_000)).collect::<RoaringTreemap>();
+    assert!(sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmaps_not() {
-    let sup = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_006_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let sub = RoaringTreemap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
-    assert_eq!(sub.is_subset(&sup), false);
+    let sup = ((0..6000)
+        .chain(1_000_000..1_006_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
+    let sub = ((100_000..106_000).chain(1_100_000..1_106_000)).collect::<RoaringTreemap>();
+    assert!(!sub.is_subset(&sup));
 }
 
 #[test]
 fn bitmaps() {
-    let sup = RoaringTreemap::from_iter((0..1_000_000).chain(2_000_000..2_010_000));
-    let sub = RoaringTreemap::from_iter((0..10_000).chain(500_000..510_000));
-    assert_eq!(sub.is_subset(&sup), true);
+    let sup = ((0..1_000_000).chain(2_000_000..2_010_000)).collect::<RoaringTreemap>();
+    let sub = ((0..10_000).chain(500_000..510_000)).collect::<RoaringTreemap>();
+    assert!(sub.is_subset(&sup));
 }

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 
 #[test]
 fn array() {
-    let original = RoaringTreemap::from_iter(0..2000);
+    let original = (0..2000).collect::<RoaringTreemap>();
     let clone = RoaringTreemap::from_iter(&original);
     let clone2 = RoaringTreemap::from_iter(original.clone());
 
@@ -15,7 +15,7 @@ fn array() {
 
 #[test]
 fn bitmap() {
-    let original = RoaringTreemap::from_iter(0..6000);
+    let original = (0..6000).collect::<RoaringTreemap>();
     let clone = RoaringTreemap::from_iter(&original);
     let clone2 = RoaringTreemap::from_iter(original.clone());
 
@@ -25,11 +25,10 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
+    let original = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
     let clone = RoaringTreemap::from_iter(&original);
     let clone2 = RoaringTreemap::from_iter(original.clone());
 
@@ -39,11 +38,10 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let original = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
     let clone = RoaringTreemap::from_iter(&original);
     let clone2 = RoaringTreemap::from_iter(original.clone());
 
@@ -53,13 +51,15 @@ fn bitmaps() {
 
 #[test]
 fn bitmaps_iterator() {
-    let original = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let original = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
     let clone = RoaringTreemap::from_bitmaps(original.bitmaps().map(|(p, b)| (p, b.clone())));
-    let clone2 = RoaringTreemap::from_iter(original.bitmaps().map(|(p, b)| (p, b.clone())));
+    let clone2 = original
+        .bitmaps()
+        .map(|(p, b)| (p, b.clone()))
+        .collect::<RoaringTreemap>();
 
     assert_eq!(clone, original);
     assert_eq!(clone2, original);

--- a/tests/treemap_lib.rs
+++ b/tests/treemap_lib.rs
@@ -1,38 +1,36 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn smoke() {
     let mut bitmap = RoaringTreemap::new();
     assert_eq!(bitmap.len(), 0);
-    assert_eq!(bitmap.is_empty(), true);
+    assert!(bitmap.is_empty());
     bitmap.remove(0);
     assert_eq!(bitmap.len(), 0);
-    assert_eq!(bitmap.is_empty(), true);
+    assert!(bitmap.is_empty());
     bitmap.insert(1);
-    assert_eq!(bitmap.contains(1), true);
+    assert!(bitmap.contains(1));
     assert_eq!(bitmap.len(), 1);
-    assert_eq!(bitmap.is_empty(), false);
+    assert!(!bitmap.is_empty());
     bitmap.insert(u64::max_value() - 2);
-    assert_eq!(bitmap.contains(u64::max_value() - 2), true);
+    assert!(bitmap.contains(u64::max_value() - 2));
     assert_eq!(bitmap.len(), 2);
     bitmap.insert(u64::max_value());
-    assert_eq!(bitmap.contains(u64::max_value()), true);
+    assert!(bitmap.contains(u64::max_value()));
     assert_eq!(bitmap.len(), 3);
     bitmap.insert(2);
-    assert_eq!(bitmap.contains(2), true);
+    assert!(bitmap.contains(2));
     assert_eq!(bitmap.len(), 4);
     bitmap.remove(2);
-    assert_eq!(bitmap.contains(2), false);
+    assert!(!bitmap.contains(2));
     assert_eq!(bitmap.len(), 3);
-    assert_eq!(bitmap.contains(0), false);
-    assert_eq!(bitmap.contains(1), true);
-    assert_eq!(bitmap.contains(100), false);
-    assert_eq!(bitmap.contains(u64::max_value() - 2), true);
-    assert_eq!(bitmap.contains(u64::max_value() - 1), false);
-    assert_eq!(bitmap.contains(u64::max_value()), true);
+    assert!(!bitmap.contains(0));
+    assert!(bitmap.contains(1));
+    assert!(!bitmap.contains(100));
+    assert!(bitmap.contains(u64::max_value() - 2));
+    assert!(!bitmap.contains(u64::max_value() - 1));
+    assert!(bitmap.contains(u64::max_value()));
 }
 
 #[test]
@@ -51,9 +49,12 @@ fn remove_range() {
     ];
     for (i, &a) in ranges.iter().enumerate() {
         for &b in &ranges[i..] {
-            let mut bitmap = RoaringTreemap::from_iter(0..=65536);
+            let mut bitmap = (0..=65536).collect::<RoaringTreemap>();
             assert_eq!(bitmap.remove_range(a..b), (b - a));
-            assert_eq!(bitmap, RoaringTreemap::from_iter((0..a).chain(b..=65536)));
+            assert_eq!(
+                bitmap,
+                ((0..a).chain(b..=65536)).collect::<RoaringTreemap>()
+            );
         }
     }
 }
@@ -84,25 +85,25 @@ fn test_min() {
 
 #[test]
 fn to_bitmap() {
-    let bitmap = RoaringTreemap::from_iter(0..5000);
+    let bitmap = (0..5000).collect::<RoaringTreemap>();
     assert_eq!(bitmap.len(), 5000);
     for i in 1..5000 {
-        assert_eq!(bitmap.contains(i), true);
+        assert!(bitmap.contains(i));
     }
-    assert_eq!(bitmap.contains(5001), false);
+    assert!(!bitmap.contains(5001));
 }
 
 #[test]
 fn to_array() {
-    let mut bitmap = RoaringTreemap::from_iter(0..5000);
+    let mut bitmap = (0..5000).collect::<RoaringTreemap>();
     for i in 3000..5000 {
         bitmap.remove(i);
     }
     assert_eq!(bitmap.len(), 3000);
     for i in 0..3000 {
-        assert_eq!(bitmap.contains(i), true);
+        assert!(bitmap.contains(i));
     }
     for i in 3000..5000 {
-        assert_eq!(bitmap.contains(i), false);
+        assert!(!bitmap.contains(i));
     }
 }

--- a/tests/treemap_ops.rs
+++ b/tests/treemap_ops.rs
@@ -1,13 +1,11 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn or() {
-    let mut rb1 = RoaringTreemap::from_iter(1..4);
-    let rb2 = RoaringTreemap::from_iter(3..6);
-    let rb3 = RoaringTreemap::from_iter(1..6);
+    let mut rb1 = (1..4).collect::<RoaringTreemap>();
+    let rb2 = (3..6).collect::<RoaringTreemap>();
+    let rb3 = (1..6).collect::<RoaringTreemap>();
 
     assert_eq!(rb3, &rb1 | &rb2);
     assert_eq!(rb3, &rb1 | rb2.clone());
@@ -22,9 +20,9 @@ fn or() {
 
 #[test]
 fn and() {
-    let mut rb1 = RoaringTreemap::from_iter(1..4);
-    let rb2 = RoaringTreemap::from_iter(3..6);
-    let rb3 = RoaringTreemap::from_iter(3..4);
+    let mut rb1 = (1..4).collect::<RoaringTreemap>();
+    let rb2 = (3..6).collect::<RoaringTreemap>();
+    let rb3 = (3..4).collect::<RoaringTreemap>();
 
     assert_eq!(rb3, &rb1 & &rb2);
     assert_eq!(rb3, &rb1 & rb2.clone());
@@ -39,9 +37,9 @@ fn and() {
 
 #[test]
 fn sub() {
-    let mut rb1 = RoaringTreemap::from_iter(1..4);
-    let rb2 = RoaringTreemap::from_iter(3..6);
-    let rb3 = RoaringTreemap::from_iter(1..3);
+    let mut rb1 = (1..4).collect::<RoaringTreemap>();
+    let rb2 = (3..6).collect::<RoaringTreemap>();
+    let rb3 = (1..3).collect::<RoaringTreemap>();
 
     assert_eq!(rb3, &rb1 - &rb2);
     assert_eq!(rb3, &rb1 - rb2.clone());
@@ -56,10 +54,10 @@ fn sub() {
 
 #[test]
 fn xor() {
-    let mut rb1 = RoaringTreemap::from_iter(1..4);
-    let rb2 = RoaringTreemap::from_iter(3..6);
-    let rb3 = RoaringTreemap::from_iter((1..3).chain(4..6));
-    let rb4 = RoaringTreemap::from_iter(0..0);
+    let mut rb1 = (1..4).collect::<RoaringTreemap>();
+    let rb2 = (3..6).collect::<RoaringTreemap>();
+    let rb3 = ((1..3).chain(4..6)).collect::<RoaringTreemap>();
+    let rb4 = (0..0).collect::<RoaringTreemap>();
 
     assert_eq!(rb3, &rb1 ^ &rb2);
     assert_eq!(rb3, &rb1 ^ rb2.clone());

--- a/tests/treemap_size_hint.rs
+++ b/tests/treemap_size_hint.rs
@@ -1,11 +1,9 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
-    let bitmap = RoaringTreemap::from_iter(0..2000);
+    let bitmap = (0..2000).collect::<RoaringTreemap>();
     let mut iter = bitmap.iter();
     assert_eq!((2000, Some(2000)), iter.size_hint());
     iter.by_ref().take(1000).for_each(drop);
@@ -16,7 +14,7 @@ fn array() {
 
 #[test]
 fn bitmap() {
-    let bitmap = RoaringTreemap::from_iter(0..6000);
+    let bitmap = (0..6000).collect::<RoaringTreemap>();
     let mut iter = bitmap.iter();
     assert_eq!((6000, Some(6000)), iter.size_hint());
     iter.by_ref().take(3000).for_each(drop);
@@ -27,11 +25,10 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let bitmap = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(2_000_000..2_001_000),
-    );
+    let bitmap = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
     let mut iter = bitmap.iter();
     assert_eq!((5000, Some(5000)), iter.size_hint());
     iter.by_ref().take(3000).for_each(drop);
@@ -42,11 +39,10 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let bitmap = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(2_000_000..2_010_000),
-    );
+    let bitmap = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
     let mut iter = bitmap.iter();
     assert_eq!((28000, Some(28000)), iter.size_hint());
     iter.by_ref().take(2000).for_each(drop);

--- a/tests/treemap_symmetric_difference_with.rs
+++ b/tests/treemap_symmetric_difference_with.rs
@@ -9,7 +9,7 @@ fn array() {
     let bitmap2 = RoaringTreemap::from_iter(1000..3000);
     let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(2000..3000));
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -19,7 +19,7 @@ fn no_symmetric_difference() {
     let mut bitmap1 = RoaringTreemap::from_iter(0..2);
     let bitmap2 = RoaringTreemap::from_iter(0..2);
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, RoaringTreemap::new());
 }
@@ -30,7 +30,7 @@ fn array_and_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(1000..8000);
     let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(2000..8000));
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -41,7 +41,7 @@ fn bitmap_to_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(6000..18000);
     let bitmap3 = RoaringTreemap::from_iter((0..6000).chain(12000..18000));
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -52,7 +52,7 @@ fn bitmap_to_array() {
     let bitmap2 = RoaringTreemap::from_iter(2000..7000);
     let bitmap3 = RoaringTreemap::from_iter((0..2000).chain(6000..7000));
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -63,7 +63,7 @@ fn bitmap_and_array_to_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(11000..14000);
     let bitmap3 = RoaringTreemap::from_iter((0..11000).chain(12000..14000));
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -74,7 +74,7 @@ fn bitmap_and_array_to_array() {
     let bitmap2 = RoaringTreemap::from_iter(3000..7000);
     let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(6000..7000));
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -100,7 +100,7 @@ fn arrays() {
             .chain(3_000_000..3_001_000),
     );
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -126,7 +126,7 @@ fn bitmaps() {
             .chain(3_000_000..3_010_000),
     );
 
-    bitmap1.symmetric_difference_with(&bitmap2);
+    bitmap1 ^= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/treemap_symmetric_difference_with.rs
+++ b/tests/treemap_symmetric_difference_with.rs
@@ -1,13 +1,11 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..3000);
-    let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(2000..3000));
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..3000).collect::<RoaringTreemap>();
+    let bitmap3 = ((0..1000).chain(2000..3000)).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -16,8 +14,8 @@ fn array() {
 
 #[test]
 fn no_symmetric_difference() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2);
-    let bitmap2 = RoaringTreemap::from_iter(0..2);
+    let mut bitmap1 = (0..2).collect::<RoaringTreemap>();
+    let bitmap2 = (0..2).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -26,9 +24,9 @@ fn no_symmetric_difference() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..8000);
-    let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(2000..8000));
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..8000).collect::<RoaringTreemap>();
+    let bitmap3 = ((0..1000).chain(2000..8000)).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -37,9 +35,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap_to_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(6000..18000);
-    let bitmap3 = RoaringTreemap::from_iter((0..6000).chain(12000..18000));
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (6000..18000).collect::<RoaringTreemap>();
+    let bitmap3 = ((0..6000).chain(12000..18000)).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -48,9 +46,9 @@ fn bitmap_to_bitmap() {
 
 #[test]
 fn bitmap_to_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..6000);
-    let bitmap2 = RoaringTreemap::from_iter(2000..7000);
-    let bitmap3 = RoaringTreemap::from_iter((0..2000).chain(6000..7000));
+    let mut bitmap1 = (0..6000).collect::<RoaringTreemap>();
+    let bitmap2 = (2000..7000).collect::<RoaringTreemap>();
+    let bitmap3 = ((0..2000).chain(6000..7000)).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -59,9 +57,9 @@ fn bitmap_to_array() {
 
 #[test]
 fn bitmap_and_array_to_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(11000..14000);
-    let bitmap3 = RoaringTreemap::from_iter((0..11000).chain(12000..14000));
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (11000..14000).collect::<RoaringTreemap>();
+    let bitmap3 = ((0..11000).chain(12000..14000)).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -70,9 +68,9 @@ fn bitmap_and_array_to_bitmap() {
 
 #[test]
 fn bitmap_and_array_to_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..6000);
-    let bitmap2 = RoaringTreemap::from_iter(3000..7000);
-    let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(6000..7000));
+    let mut bitmap1 = (0..6000).collect::<RoaringTreemap>();
+    let bitmap2 = (3000..7000).collect::<RoaringTreemap>();
+    let bitmap3 = ((0..3000).chain(6000..7000)).collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -81,24 +79,21 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(3_000_000..3_001_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_000_001),
-    );
-    let bitmap3 = RoaringTreemap::from_iter(
-        (0..1000)
-            .chain(1_000_000..1_001_000)
-            .chain(2000..3000)
-            .chain(1_002_000..1_003_000)
-            .chain(2_000_000..2_000_001)
-            .chain(3_000_000..3_001_000),
-    );
+    let mut bitmap1 = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(3_000_000..3_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_000_001))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((0..1000)
+        .chain(1_000_000..1_001_000)
+        .chain(2000..3000)
+        .chain(1_002_000..1_003_000)
+        .chain(2_000_000..2_000_001)
+        .chain(3_000_000..3_001_000))
+    .collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 
@@ -107,24 +102,21 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(3_000_000..3_010_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (3000..7000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter(
-        (0..3000)
-            .chain(1_000_000..1_006_000)
-            .chain(6000..7000)
-            .chain(1_012_000..1_018_000)
-            .chain(2_000_000..2_010_000)
-            .chain(3_000_000..3_010_000),
-    );
+    let mut bitmap1 = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(3_000_000..3_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((3000..7000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((0..3000)
+        .chain(1_000_000..1_006_000)
+        .chain(6000..7000)
+        .chain(1_012_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .chain(3_000_000..3_010_000))
+    .collect::<RoaringTreemap>();
 
     bitmap1 ^= bitmap2;
 

--- a/tests/treemap_union_with.rs
+++ b/tests/treemap_union_with.rs
@@ -9,7 +9,7 @@ fn array_to_array() {
     let bitmap2 = RoaringTreemap::from_iter(1000..3000);
     let bitmap3 = RoaringTreemap::from_iter(0..3000);
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -20,7 +20,7 @@ fn array_to_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(4000..8000);
     let bitmap3 = RoaringTreemap::from_iter(0..8000);
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -31,7 +31,7 @@ fn array_and_bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(1000..8000);
     let bitmap3 = RoaringTreemap::from_iter(0..8000);
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -42,7 +42,7 @@ fn bitmap() {
     let bitmap2 = RoaringTreemap::from_iter(6000..18000);
     let bitmap3 = RoaringTreemap::from_iter(0..18000);
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -53,7 +53,7 @@ fn bitmap_and_array() {
     let bitmap2 = RoaringTreemap::from_iter(10000..13000);
     let bitmap3 = RoaringTreemap::from_iter(0..13000);
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -77,7 +77,7 @@ fn arrays() {
             .chain(3_000_000..3_001_000),
     );
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -101,7 +101,7 @@ fn bitmaps() {
             .chain(3_000_000..3_010_000),
     );
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }

--- a/tests/treemap_union_with.rs
+++ b/tests/treemap_union_with.rs
@@ -1,13 +1,11 @@
 extern crate roaring;
 use roaring::RoaringTreemap;
 
-use std::iter::FromIterator;
-
 #[test]
 fn array_to_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..3000);
-    let bitmap3 = RoaringTreemap::from_iter(0..3000);
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..3000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..3000).collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 
@@ -16,9 +14,9 @@ fn array_to_array() {
 
 #[test]
 fn array_to_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..4000);
-    let bitmap2 = RoaringTreemap::from_iter(4000..8000);
-    let bitmap3 = RoaringTreemap::from_iter(0..8000);
+    let mut bitmap1 = (0..4000).collect::<RoaringTreemap>();
+    let bitmap2 = (4000..8000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..8000).collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 
@@ -27,9 +25,9 @@ fn array_to_bitmap() {
 
 #[test]
 fn array_and_bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..2000);
-    let bitmap2 = RoaringTreemap::from_iter(1000..8000);
-    let bitmap3 = RoaringTreemap::from_iter(0..8000);
+    let mut bitmap1 = (0..2000).collect::<RoaringTreemap>();
+    let bitmap2 = (1000..8000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..8000).collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 
@@ -38,9 +36,9 @@ fn array_and_bitmap() {
 
 #[test]
 fn bitmap() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(6000..18000);
-    let bitmap3 = RoaringTreemap::from_iter(0..18000);
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (6000..18000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..18000).collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 
@@ -49,9 +47,9 @@ fn bitmap() {
 
 #[test]
 fn bitmap_and_array() {
-    let mut bitmap1 = RoaringTreemap::from_iter(0..12000);
-    let bitmap2 = RoaringTreemap::from_iter(10000..13000);
-    let bitmap3 = RoaringTreemap::from_iter(0..13000);
+    let mut bitmap1 = (0..12000).collect::<RoaringTreemap>();
+    let bitmap2 = (10000..13000).collect::<RoaringTreemap>();
+    let bitmap3 = (0..13000).collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 
@@ -60,22 +58,19 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..2000)
-            .chain(1_000_000..1_002_000)
-            .chain(3_000_000..3_001_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (1000..3000)
-            .chain(1_001_000..1_003_000)
-            .chain(2_000_000..2_001_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter(
-        (0..3000)
-            .chain(1_000_000..1_003_000)
-            .chain(2_000_000..2_001_000)
-            .chain(3_000_000..3_001_000),
-    );
+    let mut bitmap1 = ((0..2000)
+        .chain(1_000_000..1_002_000)
+        .chain(3_000_000..3_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((1000..3000)
+        .chain(1_001_000..1_003_000)
+        .chain(2_000_000..2_001_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((0..3000)
+        .chain(1_000_000..1_003_000)
+        .chain(2_000_000..2_001_000)
+        .chain(3_000_000..3_001_000))
+    .collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 
@@ -84,22 +79,19 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter(
-        (0..6000)
-            .chain(1_000_000..1_012_000)
-            .chain(3_000_000..3_010_000),
-    );
-    let bitmap2 = RoaringTreemap::from_iter(
-        (3000..9000)
-            .chain(1_006_000..1_018_000)
-            .chain(2_000_000..2_010_000),
-    );
-    let bitmap3 = RoaringTreemap::from_iter(
-        (0..9000)
-            .chain(1_000_000..1_018_000)
-            .chain(2_000_000..2_010_000)
-            .chain(3_000_000..3_010_000),
-    );
+    let mut bitmap1 = ((0..6000)
+        .chain(1_000_000..1_012_000)
+        .chain(3_000_000..3_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap2 = ((3000..9000)
+        .chain(1_006_000..1_018_000)
+        .chain(2_000_000..2_010_000))
+    .collect::<RoaringTreemap>();
+    let bitmap3 = ((0..9000)
+        .chain(1_000_000..1_018_000)
+        .chain(2_000_000..2_010_000)
+        .chain(3_000_000..3_010_000))
+    .collect::<RoaringTreemap>();
 
     bitmap1 |= bitmap2;
 

--- a/tests/union_with.rs
+++ b/tests/union_with.rs
@@ -7,7 +7,7 @@ fn array_to_array() {
     let bitmap2 = (1000..3000).collect::<RoaringBitmap>();
     let bitmap3 = (0..3000).collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -18,7 +18,7 @@ fn array_to_bitmap() {
     let bitmap2 = (4000..8000).collect::<RoaringBitmap>();
     let bitmap3 = (0..8000).collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -29,7 +29,7 @@ fn array_and_bitmap() {
     let bitmap2 = (1000..8000).collect::<RoaringBitmap>();
     let bitmap3 = (0..8000).collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -40,7 +40,7 @@ fn bitmap() {
     let bitmap2 = (6000..18000).collect::<RoaringBitmap>();
     let bitmap3 = (0..18000).collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -51,7 +51,7 @@ fn bitmap_and_array() {
     let bitmap2 = (10000..13000).collect::<RoaringBitmap>();
     let bitmap3 = (0..13000).collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -72,7 +72,7 @@ fn arrays() {
         .chain(3_000_000..3_001_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }
@@ -93,7 +93,7 @@ fn bitmaps() {
         .chain(3_000_000..3_010_000)
         .collect::<RoaringBitmap>();
 
-    bitmap1.union_with(&bitmap2);
+    bitmap1 |= bitmap2;
 
     assert_eq!(bitmap1, bitmap3);
 }


### PR DESCRIPTION
This pull request fixes #95 by implementing better versions of the set operations (union, intersection, difference, and symmetric difference) by efficiently using [the standard ops traits](https://doc.rust-lang.org/std/ops/trait.BitOr.html) (`BitOr`, `BitAnd`, `Sub`, and `BitXor`) with the concept of ownership. For example, if an operation must be done on two owned types, the library will take the owned internal store instead of cloning them.

In [a previous pull request](https://github.com/RoaringBitmap/roaring-rs/issues/94) we made the first step toward a more efficient version of the `RoaringBitmap` standard ops traits, but it was not applied to the `Container` and `Store` internal types, so the result was good but not enough.

We also decided it was mandatory to deprecate the [raw operation methods](https://docs.rs/roaring/0.6.6/roaring/bitmap/struct.RoaringBitmap.html#impl-4) (`union_with`, `intersect_with`, `difference_with`, `symmetric_difference_with`) as those were only exposing one way to do the operations (mutable with borrowed) when users could sometime provide two owned bitmaps and get performance gains by using [the appropriate ops trait variant](https://docs.rs/roaring/0.6.6/roaring/bitmap/struct.RoaringBitmap.html#impl-BitAnd%3C%26%27_%20RoaringBitmap%3E). The only downside of eventually removing these raw methods is the loss in clarity, for me, at least, it is easier to understand `intersect_with` than `&=` or `BitAndAssign::bitand_assign`.