### PR TITLE
Non panicking push method

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -52,10 +52,16 @@ impl Container {
         inserted
     }
 
-    pub fn push(&mut self, index: u16) {
+    /// Pushes `index` at the end of the container only if `index` is the new max.
+    ///
+    /// Returns whether the `index` was effectively pushed.
+    pub fn push(&mut self, index: u16) -> bool {
         if self.store.push(index) {
             self.len += 1;
             self.ensure_correct_store();
+            true
+        } else {
+            false
         }
     }
 
@@ -92,11 +98,11 @@ impl Container {
         self.len <= other.len && self.store.is_subset(&other.store)
     }
 
-    pub fn min(&self) -> u16 {
+    pub fn min(&self) -> Option<u16> {
         self.store.min()
     }
 
-    pub fn max(&self) -> u16 {
+    pub fn max(&self) -> Option<u16> {
         self.store.max()
     }
 

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -41,10 +41,9 @@ impl RoaringTreemap {
             .insert(lo)
     }
 
-    /// Adds a value to the set.
-    /// The value **must** be greater or equal to the maximum value in the set.
+    /// Pushes `value` in the treemap only if it is greater than the current maximum value.
     ///
-    /// This method can be faster than `insert` because it skips the binary searches.
+    /// Returns whether the value was inserted.
     ///
     /// # Examples
     ///
@@ -52,13 +51,14 @@ impl RoaringTreemap {
     /// use roaring::RoaringTreemap;
     ///
     /// let mut rb = RoaringTreemap::new();
-    /// rb.push(1);
-    /// rb.push(3);
-    /// rb.push(5);
+    /// assert!(rb.push(1));
+    /// assert!(rb.push(3));
+    /// assert_eq!(rb.push(3), false);
+    /// assert!(rb.push(5));
     ///
     /// assert_eq!(rb.iter().collect::<Vec<u64>>(), vec![1, 3, 5]);
     /// ```
-    pub fn push(&mut self, value: u64) {
+    pub fn push(&mut self, value: u64) -> bool {
         let (hi, lo) = util::split(value);
         self.map
             .entry(hi)


### PR DESCRIPTION
Changes the `push` method to make it not panic when inserting a value that is not greater than the previous. Also make some optimizations that make the push method roughly 20% faster than before.
