### PR TITLE
Improve RoaringBitmap ref with ref set operations

### DIFF
--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -134,6 +134,15 @@ fn union_with(c: &mut Criterion) {
     });
 }
 
+fn sub(c: &mut Criterion) {
+    c.bench_function("sub", |b| {
+        let bitmap1: RoaringBitmap = (1..100_000).collect();
+        let bitmap2: RoaringBitmap = (10..2_000_000).collect();
+
+        b.iter(|| &bitmap1 - &bitmap2);
+    });
+}
+
 fn xor(c: &mut Criterion) {
     c.bench_function("xor", |b| {
         let bitmap1: RoaringBitmap = (1..100).collect();
@@ -449,6 +458,7 @@ criterion_group!(
     intersect_with,
     or,
     union_with,
+    sub,
     xor,
     symmetric_deference_with,
     is_subset,

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -146,11 +146,7 @@ impl BitAnd<&Container> for &Container {
 
     fn bitand(self, rhs: &Container) -> Container {
         let store = BitAnd::bitand(&self.store, &rhs.store);
-        let mut container = Container {
-            key: self.key,
-            len: store.len(),
-            store,
-        };
+        let mut container = Container { key: self.key, len: store.len(), store };
         container.ensure_correct_store();
         container
     }
@@ -172,6 +168,17 @@ impl BitAndAssign<&Container> for Container {
     }
 }
 
+impl Sub<&Container> for &Container {
+    type Output = Container;
+
+    fn sub(self, rhs: &Container) -> Container {
+        let store = Sub::sub(&self.store, &rhs.store);
+        let mut container = Container { key: self.key, len: store.len(), store };
+        container.ensure_correct_store();
+        container
+    }
+}
+
 impl SubAssign<&Container> for Container {
     fn sub_assign(&mut self, rhs: &Container) {
         SubAssign::sub_assign(&mut self.store, &rhs.store);
@@ -185,11 +192,7 @@ impl BitXor<&Container> for &Container {
 
     fn bitxor(self, rhs: &Container) -> Container {
         let store = BitXor::bitxor(&self.store, &rhs.store);
-        let mut container = Container {
-            key: self.key,
-            len: store.len(),
-            store,
-        };
+        let mut container = Container { key: self.key, len: store.len(), store };
         container.ensure_correct_store();
         container
     }

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -138,6 +138,21 @@ impl BitOrAssign<&Container> for Container {
         BitOrAssign::bitor_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
+    }
+}
+
+impl BitAnd<&Container> for &Container {
+    type Output = Container;
+
+    fn bitand(self, rhs: &Container) -> Container {
+        let store = BitAnd::bitand(&self.store, &rhs.store);
+        let mut container = Container {
+            key: self.key,
+            len: store.len(),
+            store,
+        };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -177,6 +177,21 @@ impl SubAssign<&Container> for Container {
         SubAssign::sub_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
+    }
+}
+
+impl BitXor<&Container> for &Container {
+    type Output = Container;
+
+    fn bitxor(self, rhs: &Container) -> Container {
+        let store = BitXor::bitxor(&self.store, &rhs.store);
+        let mut container = Container {
+            key: self.key,
+            len: store.len(),
+            store,
+        };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -111,6 +111,17 @@ impl Container {
         if let Some(new_store) = new_store {
             self.store = new_store;
         }
+    }
+}
+
+impl BitOr<&Container> for &Container {
+    type Output = Container;
+
+    fn bitor(self, rhs: &Container) -> Container {
+        let store = BitOr::bitor(&self.store, &rhs.store);
+        let mut container = Container { key: self.key, len: store.len(), store };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -1,5 +1,6 @@
-use std::mem;
+use std::cmp::Ordering;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
+use std::{cmp, mem};
 
 use retain_mut::RetainMut;
 
@@ -191,11 +192,34 @@ impl BitOr<&RoaringBitmap> for &RoaringBitmap {
 
     /// An `union` between two sets.
     fn bitor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
-        if self.len() <= rhs.len() {
-            BitOr::bitor(rhs.clone(), self)
-        } else {
-            BitOr::bitor(self.clone(), rhs)
+        let len = cmp::max(self.containers.len(), rhs.containers.len());
+        let mut containers = Vec::with_capacity(len);
+
+        let mut iter_lhs = self.containers.iter().peekable();
+        let mut iter_rhs = rhs.containers.iter().peekable();
+
+        loop {
+            match (iter_lhs.peek(), iter_rhs.peek()) {
+                (Some(lhs), Some(rhs)) => {
+                    let container = match lhs.key.cmp(&rhs.key) {
+                        Ordering::Less => iter_lhs.next().cloned().unwrap(),
+                        Ordering::Greater => iter_rhs.next().cloned().unwrap(),
+                        Ordering::Equal => {
+                            let container = BitOr::bitor(*lhs, *rhs);
+                            iter_lhs.next();
+                            iter_rhs.next();
+                            container
+                        }
+                    };
+                    containers.push(container);
+                }
+                (Some(_), None) => containers.extend(iter_lhs.by_ref().cloned()),
+                (None, Some(_)) => containers.extend(iter_rhs.by_ref().cloned()),
+                (None, None) => break,
+            }
         }
+
+        RoaringBitmap { containers }
     }
 }
 

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -205,10 +205,8 @@ impl BitOr<&RoaringBitmap> for &RoaringBitmap {
                         Ordering::Less => iter_lhs.next().cloned().unwrap(),
                         Ordering::Greater => iter_rhs.next().cloned().unwrap(),
                         Ordering::Equal => {
-                            let container = BitOr::bitor(*lhs, *rhs);
-                            iter_lhs.next();
-                            iter_rhs.next();
-                            container
+                            let (lhs, rhs) = iter_lhs.next().zip(iter_rhs.next()).unwrap();
+                            BitOr::bitor(lhs, rhs)
                         }
                     };
                     containers.push(container);
@@ -454,11 +452,35 @@ impl BitXor<&RoaringBitmap> for &RoaringBitmap {
 
     /// A `symmetric difference` between two sets.
     fn bitxor(self, rhs: &RoaringBitmap) -> RoaringBitmap {
-        if self.len() < rhs.len() {
-            BitXor::bitxor(self, rhs.clone())
-        } else {
-            BitXor::bitxor(self.clone(), rhs)
+        let mut containers = Vec::new();
+        let mut iter_lhs = self.containers.iter().peekable();
+        let mut iter_rhs = rhs.containers.iter().peekable();
+
+        loop {
+            match (iter_lhs.peek(), iter_rhs.peek()) {
+                (None, None) => break,
+                (Some(_), None) => containers.extend(iter_lhs.by_ref().cloned()),
+                (None, Some(_)) => containers.extend(iter_rhs.by_ref().cloned()),
+                (Some(lhs), Some(rhs)) => {
+                    let container = match lhs.key.cmp(&rhs.key) {
+                        Ordering::Equal => {
+                            let (lhs, rhs) = iter_lhs.next().zip(iter_rhs.next()).unwrap();
+                            let container = BitXor::bitxor(lhs, rhs);
+                            if container.len != 0 {
+                                container
+                            } else {
+                                continue;
+                            }
+                        }
+                        Ordering::Less => iter_lhs.next().cloned().unwrap(),
+                        Ordering::Greater => iter_rhs.next().cloned().unwrap(),
+                    };
+                    containers.push(container);
+                }
+            }
         }
+
+        RoaringBitmap { containers }
     }
 }
 

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -293,19 +293,21 @@ impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
         loop {
             match (iter_lhs.peek(), iter_rhs.peek()) {
                 (None, None) => break,
-                (Some(lhs), Some(rhs)) => {
-                    if lhs.key == rhs.key {
+                (Some(lhs), Some(rhs)) => match lhs.key.cmp(&rhs.key) {
+                    Ordering::Equal => {
                         let (lhs, rhs) = iter_lhs.next().zip(iter_rhs.next()).unwrap();
                         let container = BitAnd::bitand(lhs, rhs);
                         if container.len != 0 {
                             containers.push(container);
                         }
-                    } else if lhs.key < rhs.key {
+                    }
+                    Ordering::Less => {
                         iter_lhs.next().unwrap();
-                    } else {
+                    }
+                    Ordering::Greater => {
                         iter_rhs.next().unwrap();
                     }
-                }
+                },
                 (Some(_), None) => {
                     iter_lhs.next().unwrap();
                 }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
 
@@ -300,6 +300,31 @@ impl Store {
                 .rev()
                 .find(|&(_, &bit)| bit != 0)
                 .map(|(index, bit)| (index * 64 + (63 - bit.leading_zeros() as usize)) as u16),
+        }
+    }
+}
+
+impl BitOr<&Store> for &Store {
+    type Output = Store;
+
+    fn bitor(self, rhs: &Store) -> Store {
+        match (self, rhs) {
+            (&Array(ref vec1), &Array(ref vec2)) => Array(union_arrays(vec1, vec2)),
+            (&Bitmap(_), &Array(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Bitmap(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Array(_), &Bitmap(_)) => {
+                let mut rhs = rhs.clone();
+                BitOrAssign::bitor_assign(&mut rhs, self);
+                rhs
+            }
         }
     }
 }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -389,12 +389,7 @@ impl BitAnd<&Store> for &Store {
                 BitAndAssign::bitand_assign(&mut rhs, self);
                 rhs
             }
-            (&Bitmap(_), &Bitmap(_)) => {
-                let mut lhs = self.clone();
-                BitAndAssign::bitand_assign(&mut lhs, rhs);
-                lhs
-            }
-            (&Array(_), &Bitmap(_)) => {
+            _ => {
                 let mut lhs = self.clone();
                 BitAndAssign::bitand_assign(&mut lhs, rhs);
                 lhs
@@ -476,17 +471,7 @@ impl Sub<&Store> for &Store {
     fn sub(self, rhs: &Store) -> Store {
         match (self, rhs) {
             (&Array(ref vec1), &Array(ref vec2)) => Array(difference_arrays(vec1, vec2)),
-            (&Bitmap(_), &Array(_)) => {
-                let mut lhs = self.clone();
-                BitOrAssign::bitor_assign(&mut lhs, rhs);
-                lhs
-            }
-            (&Bitmap(_), &Bitmap(_)) => {
-                let mut lhs = self.clone();
-                BitOrAssign::bitor_assign(&mut lhs, rhs);
-                lhs
-            }
-            (&Array(_), &Bitmap(_)) => {
+            _ => {
                 let mut lhs = self.clone();
                 BitOrAssign::bitor_assign(&mut lhs, rhs);
                 lhs
@@ -528,19 +513,14 @@ impl BitXor<&Store> for &Store {
     fn bitxor(self, rhs: &Store) -> Store {
         match (self, rhs) {
             (&Array(ref vec1), &Array(ref vec2)) => Array(symmetric_difference_arrays(vec1, vec2)),
-            (&Bitmap(_), &Array(_)) => {
-                let mut lhs = self.clone();
-                BitXorAssign::bitxor_assign(&mut lhs, rhs);
-                lhs
-            }
-            (&Bitmap(_), &Bitmap(_)) => {
-                let mut lhs = self.clone();
-                BitXorAssign::bitxor_assign(&mut lhs, rhs);
-                lhs
-            }
             (&Array(_), &Bitmap(_)) => {
                 let mut lhs = rhs.clone();
                 BitXorAssign::bitxor_assign(&mut lhs, self);
+                lhs
+            }
+            _ => {
+                let mut lhs = self.clone();
+                BitXorAssign::bitxor_assign(&mut lhs, rhs);
                 lhs
             }
         }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
 
@@ -378,6 +378,31 @@ impl BitOrAssign<&Store> for Store {
     }
 }
 
+impl BitAnd<&Store> for &Store {
+    type Output = Store;
+
+    fn bitand(self, rhs: &Store) -> Store {
+        match (self, rhs) {
+            (&Array(ref vec1), &Array(ref vec2)) => Array(intersect_arrays(vec1, vec2)),
+            (&Bitmap(_), &Array(_)) => {
+                let mut rhs = rhs.clone();
+                BitAndAssign::bitand_assign(&mut rhs, self);
+                rhs
+            }
+            (&Bitmap(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitAndAssign::bitand_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Array(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitAndAssign::bitand_assign(&mut lhs, rhs);
+                lhs
+            }
+        }
+    }
+}
+
 impl BitAndAssign<Store> for Store {
     #[allow(clippy::suspicious_op_assign_impl)]
     fn bitand_assign(&mut self, mut rhs: Store) {
@@ -705,6 +730,30 @@ fn union_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
     // Store remaining elements of the arrays
     out.extend_from_slice(&arr1[i..]);
     out.extend_from_slice(&arr2[j..]);
+
+    out
+}
+
+#[inline]
+fn intersect_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
+    let mut out = Vec::new();
+
+    // Traverse both arrays
+    let mut i = 0;
+    let mut j = 0;
+    while i < arr1.len() && j < arr2.len() {
+        let a = unsafe { arr1.get_unchecked(i) };
+        let b = unsafe { arr2.get_unchecked(j) };
+        match a.cmp(&b) {
+            Less => i += 1,
+            Greater => j += 1,
+            Equal => {
+                out.push(*a);
+                i += 1;
+                j += 1;
+            }
+        }
+    }
 
     out
 }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
 
@@ -470,6 +470,31 @@ impl BitAndAssign<&Store> for Store {
     }
 }
 
+impl Sub<&Store> for &Store {
+    type Output = Store;
+
+    fn sub(self, rhs: &Store) -> Store {
+        match (self, rhs) {
+            (&Array(ref vec1), &Array(ref vec2)) => Array(difference_arrays(vec1, vec2)),
+            (&Bitmap(_), &Array(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Bitmap(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Array(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+        }
+    }
+}
+
 impl SubAssign<&Store> for Store {
     fn sub_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
@@ -779,6 +804,35 @@ fn intersect_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
             }
         }
     }
+
+    out
+}
+
+#[inline]
+fn difference_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
+    let mut out = Vec::new();
+
+    // Traverse both arrays
+    let mut i = 0;
+    let mut j = 0;
+    while i < arr1.len() && j < arr2.len() {
+        let a = unsafe { arr1.get_unchecked(i) };
+        let b = unsafe { arr2.get_unchecked(j) };
+        match a.cmp(&b) {
+            Less => {
+                out.push(*a);
+                i += 1;
+            }
+            Greater => j += 1,
+            Equal => {
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+
+    // Store remaining elements of the left array
+    out.extend_from_slice(&arr1[i..]);
 
     out
 }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
 use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
 
@@ -497,6 +497,31 @@ impl SubAssign<&Store> for Store {
     }
 }
 
+impl BitXor<&Store> for &Store {
+    type Output = Store;
+
+    fn bitxor(self, rhs: &Store) -> Store {
+        match (self, rhs) {
+            (&Array(ref vec1), &Array(ref vec2)) => Array(symmetric_difference_arrays(vec1, vec2)),
+            (&Bitmap(_), &Array(_)) => {
+                let mut lhs = self.clone();
+                BitXorAssign::bitxor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Bitmap(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitXorAssign::bitxor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Array(_), &Bitmap(_)) => {
+                let mut lhs = rhs.clone();
+                BitXorAssign::bitxor_assign(&mut lhs, self);
+                lhs
+            }
+        }
+    }
+}
+
 impl BitXorAssign<Store> for Store {
     fn bitxor_assign(&mut self, mut rhs: Store) {
         // TODO improve this function
@@ -713,11 +738,11 @@ fn union_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
         match a.cmp(&b) {
             Less => {
                 out.push(*a);
-                i += 1
+                i += 1;
             }
             Greater => {
                 out.push(*b);
-                j += 1
+                j += 1;
             }
             Equal => {
                 out.push(*a);
@@ -754,6 +779,39 @@ fn intersect_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
             }
         }
     }
+
+    out
+}
+
+#[inline]
+fn symmetric_difference_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
+    let mut out = Vec::new();
+
+    // Traverse both arrays
+    let mut i = 0;
+    let mut j = 0;
+    while i < arr1.len() && j < arr2.len() {
+        let a = unsafe { arr1.get_unchecked(i) };
+        let b = unsafe { arr2.get_unchecked(j) };
+        match a.cmp(&b) {
+            Less => {
+                out.push(*a);
+                i += 1;
+            }
+            Greater => {
+                out.push(*b);
+                j += 1;
+            }
+            Equal => {
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+
+    // Store remaining elements of the arrays
+    out.extend_from_slice(&arr1[i..]);
+    out.extend_from_slice(&arr2[j..]);
 
     out
 }


### PR DESCRIPTION
This is a follow-up of the #97 PR. It improves the specific `&RoaringBitmap` with `&RoaringBitmap` `union`, `intersection` `difference` and, `symmetric difference` operations.

The previous implementation was cloning the smallest or biggest bitmap depending on the operation and applying an `_assign` operation on it, this was not quite efficient. In this new implementation, we no more clone the containers `Vec` but rather collect the required `Container`s from the left-hand side or the right-hand side.

The performance gain is around 20% 🎉 🚀

<img width="975" alt="Capture d’écran 2021-06-02 à 15 08 02" src="https://user-images.githubusercontent.com/3610253/120485432-5f940d80-c3b4-11eb-907c-01a35b0e2ad2.png">
<img width="959" alt="Capture d’écran 2021-06-02 à 15 08 13" src="https://user-images.githubusercontent.com/3610253/120485586-8baf8e80-c3b4-11eb-84bb-33f428f34329.png">