### PR TITLE
Modify the len method to be constant-time

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -129,6 +129,15 @@ fn union_with(c: &mut Criterion) {
     });
 }
 
+fn sub(c: &mut Criterion) {
+    c.bench_function("sub", |b| {
+        let bitmap1: RoaringBitmap = (1..100_000).collect();
+        let bitmap2: RoaringBitmap = (10..2_000_000).collect();
+
+        b.iter(|| &bitmap1 - &bitmap2);
+    });
+}
+
 fn xor(c: &mut Criterion) {
     c.bench_function("xor", |b| {
         let bitmap1: RoaringBitmap = (1..100).collect();
@@ -319,6 +328,7 @@ criterion_group!(
     intersect_with,
     or,
     union_with,
+    sub,
     xor,
     symmetric_deference_with,
     is_subset,

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -177,6 +177,21 @@ impl BitAndAssign<&Container> for Container {
         BitAndAssign::bitand_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
+    }
+}
+
+impl Sub<&Container> for &Container {
+    type Output = Container;
+
+    fn sub(self, rhs: &Container) -> Container {
+        let store = Sub::sub(&self.store, &rhs.store);
+        let mut container = Container {
+            key: self.key,
+            len: store.len(),
+            store,
+        };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -146,6 +146,21 @@ impl BitOrAssign<&Container> for Container {
         BitOrAssign::bitor_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
+    }
+}
+
+impl BitAnd<&Container> for &Container {
+    type Output = Container;
+
+    fn bitand(self, rhs: &Container) -> Container {
+        let store = BitAnd::bitand(&self.store, &rhs.store);
+        let mut container = Container {
+            key: self.key,
+            len: store.len(),
+            store,
+        };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -185,6 +185,21 @@ impl SubAssign<&Container> for Container {
         SubAssign::sub_assign(&mut self.store, &rhs.store);
         self.len = self.store.len();
         self.ensure_correct_store();
+    }
+}
+
+impl BitXor<&Container> for &Container {
+    type Output = Container;
+
+    fn bitxor(self, rhs: &Container) -> Container {
+        let store = BitXor::bitxor(&self.store, &rhs.store);
+        let mut container = Container {
+            key: self.key,
+            len: store.len(),
+            store,
+        };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{fmt, ops::Range};
 
 use super::store::{self, Store};
@@ -115,6 +115,21 @@ impl Container {
         if let Some(new_store) = new_store {
             self.store = new_store;
         }
+    }
+}
+
+impl BitOr<&Container> for &Container {
+    type Output = Container;
+
+    fn bitor(self, rhs: &Container) -> Container {
+        let store = BitOr::bitor(&self.store, &rhs.store);
+        let mut container = Container {
+            key: self.key,
+            len: store.len(),
+            store,
+        };
+        container.ensure_correct_store();
+        container
     }
 }
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -33,4 +33,5 @@ pub use self::iter::Iter;
 #[derive(PartialEq, Clone)]
 pub struct RoaringBitmap {
     containers: Vec<container::Container>,
+    len: u64,
 }

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -287,11 +287,26 @@ impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
 
     /// An `intersection` between two sets.
     fn bitand(self, rhs: &RoaringBitmap) -> RoaringBitmap {
-        if rhs.len() < self.len() {
-            BitAnd::bitand(self.clone(), rhs)
-        } else {
-            BitAnd::bitand(rhs.clone(), self)
+        let mut containers = Vec::new();
+        let mut iter_lhs = self.containers.iter().peekable();
+        let mut iter_rhs = rhs.containers.iter().peekable();
+
+        loop {
+            match (iter_lhs.peek(), iter_rhs.peek()) {
+                (None, None) => break,
+                (Some(lhs), Some(rhs)) => {
+                    if lhs.key == rhs.key {
+                        let container = BitAnd::bitand(*lhs, *rhs);
+                        iter_lhs.next();
+                        iter_rhs.next();
+                        containers.push(container);
+                    }
+                }
+                _otherwise => (),
+            }
         }
+
+        RoaringBitmap { containers }
     }
 }
 

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -149,6 +149,7 @@ impl RoaringBitmap {
         }
 
         let mut containers = Vec::with_capacity(size);
+        let mut total_len = 0;
 
         for _ in 0..size {
             let key = description_bytes.read_u16::<LittleEndian>()?;
@@ -167,8 +168,12 @@ impl RoaringBitmap {
             };
 
             containers.push(Container { key, len, store });
+            total_len += len;
         }
 
-        Ok(RoaringBitmap { containers })
+        Ok(RoaringBitmap {
+            containers,
+            len: total_len,
+        })
     }
 }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
 
@@ -473,6 +473,31 @@ impl BitAndAssign<&Store> for Store {
     }
 }
 
+impl Sub<&Store> for &Store {
+    type Output = Store;
+
+    fn sub(self, rhs: &Store) -> Store {
+        match (self, rhs) {
+            (&Array(ref vec1), &Array(ref vec2)) => Array(difference_arrays(vec1, vec2)),
+            (&Bitmap(_), &Array(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Bitmap(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Array(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitOrAssign::bitor_assign(&mut lhs, rhs);
+                lhs
+            }
+        }
+    }
+}
+
 impl SubAssign<&Store> for Store {
     fn sub_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
@@ -786,6 +811,35 @@ fn intersect_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
             }
         }
     }
+
+    out
+}
+
+#[inline]
+fn difference_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
+    let mut out = Vec::new();
+
+    // Traverse both arrays
+    let mut i = 0;
+    let mut j = 0;
+    while i < arr1.len() && j < arr2.len() {
+        let a = unsafe { arr1.get_unchecked(i) };
+        let b = unsafe { arr2.get_unchecked(j) };
+        match a.cmp(&b) {
+            Less => {
+                out.push(*a);
+                i += 1;
+            }
+            Greater => j += 1,
+            Equal => {
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+
+    // Store remaining elements of the left array
+    out.extend_from_slice(&arr1[i..]);
 
     out
 }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::{BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXorAssign, SubAssign};
 use std::{borrow::Borrow, ops::Range};
 use std::{mem, slice, vec};
 
@@ -381,6 +381,31 @@ impl BitOrAssign<&Store> for Store {
     }
 }
 
+impl BitAnd<&Store> for &Store {
+    type Output = Store;
+
+    fn bitand(self, rhs: &Store) -> Store {
+        match (self, rhs) {
+            (&Array(ref vec1), &Array(ref vec2)) => Array(intersect_arrays(vec1, vec2)),
+            (&Bitmap(_), &Array(_)) => {
+                let mut rhs = rhs.clone();
+                BitAndAssign::bitand_assign(&mut rhs, self);
+                rhs
+            }
+            (&Bitmap(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitAndAssign::bitand_assign(&mut lhs, rhs);
+                lhs
+            }
+            (&Array(_), &Bitmap(_)) => {
+                let mut lhs = self.clone();
+                BitAndAssign::bitand_assign(&mut lhs, rhs);
+                lhs
+            }
+        }
+    }
+}
+
 impl BitAndAssign<Store> for Store {
     #[allow(clippy::suspicious_op_assign_impl)]
     fn bitand_assign(&mut self, mut rhs: Store) {
@@ -712,6 +737,30 @@ fn union_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
     // Store remaining elements of the arrays
     out.extend_from_slice(&arr1[i..]);
     out.extend_from_slice(&arr2[j..]);
+
+    out
+}
+
+#[inline]
+fn intersect_arrays(arr1: &[u16], arr2: &[u16]) -> Vec<u16> {
+    let mut out = Vec::new();
+
+    // Traverse both arrays
+    let mut i = 0;
+    let mut j = 0;
+    while i < arr1.len() && j < arr2.len() {
+        let a = unsafe { arr1.get_unchecked(i) };
+        let b = unsafe { arr2.get_unchecked(j) };
+        match a.cmp(&b) {
+            Less => i += 1,
+            Greater => j += 1,
+            Equal => {
+                out.push(*a);
+                i += 1;
+                j += 1;
+            }
+        }
+    }
 
     out
 }


### PR DESCRIPTION
Fixes #45.

This is a first draft, we could maybe implement some kind of wrapper or helping method to update the `RoaringBitmap` length more easily.