### PR TITLE
Improve benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path benchmarks/Cargo.toml
+          args: --benches --manifest-path benchmarks/Cargo.toml
 
       - uses: actions-rs/cargo@v1
         with:

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 roaring = { path = ".." }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3", features = ["html_reports"] }
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
 

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -372,7 +372,7 @@ fn successive_and(c: &mut Criterion) {
             |bitmaps| {
                 black_box(bitmaps.into_iter().reduce(|a, b| a & b).unwrap());
             },
-            BatchSize::SmallInput,
+            BatchSize::LargeInput,
         );
     });
 
@@ -415,7 +415,7 @@ fn successive_or(c: &mut Criterion) {
                     output |= bitmap;
                 }
             },
-            BatchSize::SmallInput,
+            BatchSize::LargeInput,
         );
     });
 

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -357,13 +357,17 @@ fn successive_and(c: &mut Criterion) {
     let mut group = c.benchmark_group("Successive And");
 
     group.bench_function("Successive And Assign Ref", |b| {
-        b.iter(|| {
-            let mut iter = bitmaps.iter();
-            let mut first = iter.next().unwrap().clone();
-            for bitmap in iter {
-                first &= bitmap;
-            }
-        });
+        b.iter_batched(
+            || bitmaps.clone(),
+            |bitmaps| {
+                let mut iter = bitmaps.into_iter();
+                let mut first = iter.next().unwrap().clone();
+                for bitmap in iter {
+                    first &= bitmap;
+                }
+            },
+            BatchSize::LargeInput,
+        );
     });
 
     group.bench_function("Successive And Assign Owned", |b| {
@@ -377,11 +381,15 @@ fn successive_and(c: &mut Criterion) {
     });
 
     group.bench_function("Successive And Ref Ref", |b| {
-        b.iter(|| {
-            let mut iter = bitmaps.iter();
-            let first = iter.next().unwrap().clone();
-            black_box(iter.fold(first, |acc, x| (&acc) & x));
-        });
+        b.iter_batched(
+            || bitmaps.clone(),
+            |bitmaps| {
+                let mut iter = bitmaps.iter();
+                let first = iter.next().unwrap().clone();
+                black_box(iter.fold(first, |acc, x| (&acc) & x));
+            },
+            BatchSize::LargeInput,
+        );
     });
 
     group.finish();

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -5,7 +5,7 @@ use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use roaring::RoaringBitmap;
 
 fn create(c: &mut Criterion) {
@@ -332,17 +332,14 @@ fn from_sorted_iter(c: &mut Criterion) {
     let files = self::datasets_paths::WIKILEAKS_NOQUOTES_SRT;
     let parsed_numbers = parse_dir_files(files).unwrap();
 
-    let mut group = c.benchmark_group("from_sorted_iter");
-    for (path, numbers) in parsed_numbers {
-        let numbers = numbers.unwrap();
-        let filename = path.file_name().unwrap().to_str().unwrap();
-        let name = format!("{} ({} integers)", filename, numbers.len());
-        let bench_id = BenchmarkId::from_parameter(name);
-        group.bench_with_input(bench_id, &numbers, |b, numbers| {
-            b.iter(|| RoaringBitmap::from_sorted_iter(numbers.iter().copied()));
-        });
-    }
-    group.finish();
+    c.bench_function("from_sorted_iter", |b| {
+        b.iter(|| {
+            for (_, numbers) in &parsed_numbers {
+                let numbers = numbers.as_ref().unwrap();
+                RoaringBitmap::from_sorted_iter(numbers.iter().copied());
+            }
+        })
+    });
 }
 
 fn successive_and(c: &mut Criterion) {


### PR DESCRIPTION
In this PR we make sure that the benchmarks are also used when testing the crate, we aggregate the `from_sorted_iter` benchmarks into one, and change the "Successive" benchmarks behavior.