### PR TITLE
Improve clone

### DIFF
--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -365,6 +365,16 @@ impl Default for RoaringBitmap {
     }
 }
 
+impl Clone for RoaringBitmap {
+    fn clone(&self) -> Self {
+        RoaringBitmap { containers: self.containers.clone() }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.containers.clone_from(&other.containers);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -30,7 +30,7 @@ pub use self::iter::Iter;
 /// rb.insert(7);
 /// println!("total bits set to true: {}", rb.len());
 /// ```
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq)]
 pub struct RoaringBitmap {
     containers: Vec<container::Container>,
 }

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -265,3 +265,13 @@ impl Default for RoaringTreemap {
         RoaringTreemap::new()
     }
 }
+
+impl Clone for RoaringTreemap {
+    fn clone(&self) -> Self {
+        RoaringTreemap { map: self.map.clone() }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.map.clone_from(&other.map);
+    }
+}

--- a/src/treemap/mod.rs
+++ b/src/treemap/mod.rs
@@ -31,7 +31,7 @@ pub use self::iter::{IntoIter, Iter};
 /// rb.insert(7);
 /// println!("total bits set to true: {}", rb.len());
 /// ```
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq)]
 pub struct RoaringTreemap {
     map: BTreeMap<u32, RoaringBitmap>,
 }


### PR DESCRIPTION
In this PR we implement the `Clone::clone_from` method, this way it is faster to clone a `RoaringBit/Treemap` by reusing a previous map if possible.