### PR TITLE
Improve the Pairs Iterator type

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -11,6 +11,7 @@ mod iter;
 mod ops;
 mod serialization;
 
+use self::cmp::Pairs;
 pub use self::iter::IntoIter;
 pub use self::iter::Iter;
 


### PR DESCRIPTION
This PR improves the Pairs Iterator to make it work with more types, it is now fully generic on the `Container` types by efficiently using [the `Borrow` trait](https://doc.rust-lang.org/std/borrow/trait.Borrow.html).

It fixes #111.