### PR TITLE
Make append O(N)

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -57,6 +57,14 @@ impl Container {
         }
     }
 
+    /// Push `index` at the end of the container.
+    /// It is up to the caller to have validated index > self.max()
+    pub(crate) fn push_unchecked(&mut self, index: u16) {
+        self.store.push_unchecked(index);
+        self.len += 1;
+        self.ensure_correct_store();
+    }
+
     pub fn remove(&mut self, index: u16) -> bool {
         if self.store.remove(index) {
             self.len -= 1;

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -151,6 +151,21 @@ impl RoaringBitmap {
         }
     }
 
+    /// Pushes `value` in the bitmap only if it is greater than the current maximum value.
+    /// It is up to the caller to have validated index > self.max()
+    pub(crate) fn push_unchecked(&mut self, value: u32) {
+        let (key, index) = util::split(value);
+
+        match self.containers.last_mut() {
+            Some(container) if container.key == key => container.push_unchecked(index),
+            _otherwise => {
+                let mut container = Container::new(key);
+                container.push_unchecked(index);
+                self.containers.push(container);
+            }
+        }
+    }
+
     /// Removes a value from the set. Returns `true` if the value was present in the set.
     ///
     /// # Examples

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -187,30 +187,25 @@ impl RoaringBitmap {
         // Name shadowed to prevent accidentally referencing the param
         let mut iterator = iterator.into_iter();
 
-        let mut prev: u32 = match iterator.next() {
-            None => return Ok(0),
-            Some(first) => {
-                if let Some(max) = self.max() {
-                    if first <= max {
-                        return Err(NonSortedIntegers { valid_until: 0 });
-                    }
-                }
-
-                first
+        let mut prev = match (iterator.next(), self.max()) {
+            (None, _) => return Ok(0),
+            (Some(first), Some(max)) if first <= max => {
+                return Err(NonSortedIntegers { valid_until: 0 })
             }
+            (Some(first), _) => first,
         };
-
-        self.insert(prev);
-        let mut count = 1;
 
         // It is now guaranteed that so long as the values are iterator are monotonically
         // increasing they must also be the greatest in the set.
+
+        self.push_unchecked(prev);
+        let mut count = 1;
 
         for value in iterator {
             if value <= prev {
                 return Err(NonSortedIntegers { valid_until: count });
             } else {
-                self.insert(value);
+                self.push_unchecked(value);
                 prev = value;
                 count += 1;
             }

--- a/src/bitmap/store.rs
+++ b/src/bitmap/store.rs
@@ -136,6 +136,18 @@ impl Store {
         }
     }
 
+    /// Push `index` at the end of the store.
+    /// It is up to the caller to have validated index > self.max()
+    pub(crate) fn push_unchecked(&mut self, index: u16) {
+        match self {
+            Array(vec) => vec.push(index),
+            Bitmap(bits) => {
+                let (key, bit) = (key(index), bit(index));
+                bits[key] |= 1 << bit;
+            }
+        }
+    }
+
     pub fn remove(&mut self, index: u16) -> bool {
         match *self {
             Array(ref mut vec) => vec.binary_search(&index).map(|loc| vec.remove(loc)).is_ok(),

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -58,6 +58,30 @@ impl RoaringTreemap {
         self.map.entry(hi).or_insert_with(RoaringBitmap::new).push(lo)
     }
 
+    /// Pushes `value` in the bitmap only if it is greater than the current maximum value.
+    /// It is up to the caller to have validated index > self.max()
+    pub(crate) fn push_unchecked(&mut self, value: u64) {
+        let (hi, lo) = util::split(value);
+        // BTreeMap last_mut not stabilized see https://github.com/rust-lang/rust/issues/62924
+        match self.map.iter_mut().next_back() {
+            None => {
+                // The tree is empty
+                let mut rb = RoaringBitmap::new();
+                rb.push_unchecked(lo);
+                self.map.insert(hi, rb);
+            }
+            Some((&key, rb)) => {
+                if key == hi {
+                    rb.push_unchecked(lo);
+                } else {
+                    let mut rb = RoaringBitmap::new();
+                    rb.push_unchecked(lo);
+                    self.map.insert(hi, rb);
+                }
+            }
+        }
+    }
+
     /// Removes a value from the set. Returns `true` if the value was present in the set.
     ///
     /// # Examples

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -255,13 +255,30 @@ impl RoaringTreemap {
         &mut self,
         iterator: I,
     ) -> Result<u64, NonSortedIntegers> {
-        let mut count = 0;
+        // Name shadowed to prevent accidentally referencing the param
+        let mut iterator = iterator.into_iter();
+
+        let mut prev = match (iterator.next(), self.max()) {
+            (None, _) => return Ok(0),
+            (Some(first), Some(max)) if first <= max => {
+                return Err(NonSortedIntegers { valid_until: 0 })
+            }
+            (Some(first), _) => first,
+        };
+
+        // It is now guaranteed that so long as the values are iterator are monotonically
+        // increasing they must also be the greatest in the set.
+
+        self.push_unchecked(prev);
+        let mut count = 1;
 
         for value in iterator {
-            if self.push(value) {
-                count += 1;
-            } else {
+            if value <= prev {
                 return Err(NonSortedIntegers { valid_until: count });
+            } else {
+                self.push_unchecked(value);
+                prev = value;
+                count += 1;
             }
         }
 


### PR DESCRIPTION
Continuation on #131 

## Summary

* Append is currently O(N logN) as it must binary search through containers on each insert. Inserting into an array container is also logN.
 * This converts append operation to O(N) by adding a crate public `push_unchecked` methods that should only be called once it's been verified that the value >= max. Eliminating both of the logN lookups

## Before
![Screen Shot 2022-01-09 at 11 13 35 PM](https://user-images.githubusercontent.com/997050/148779927-fc095082-0f22-4fdd-b7b8-dc73b333359f.png)
## After
![Screen Shot 2022-01-10 at 4 40 30 AM](https://user-images.githubusercontent.com/997050/148779952-782b9ce9-22c5-4a01-933d-7e858da3d668.png)

