### PR TITLE
Add iter size hints

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -237,7 +237,13 @@ impl<'a> Iterator for Iter<'a> {
         self.inner.next().map(|i| util::join(self.key, i))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
-        panic!("Should never be called (roaring::Iter caches the size_hint itself)")
+        self.inner.size_hint()
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {
+    fn len(&self) -> usize {
+        self.inner.len()
     }
 }
 

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -52,6 +52,13 @@ impl Iterator for Iter<'_> {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
+impl ExactSizeIterator for Iter<'_> {
+    fn len(&self) -> usize {
+        self.size_hint as usize
+    }
+}
+
 impl Iterator for IntoIter {
     type Item = u32;
 
@@ -66,6 +73,13 @@ impl Iterator for IntoIter {
         } else {
             (usize::MAX, None)
         }
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl ExactSizeIterator for IntoIter {
+    fn len(&self) -> usize {
+        self.size_hint as usize
     }
 }
 

--- a/src/bitmap/store/mod.rs
+++ b/src/bitmap/store/mod.rs
@@ -430,6 +430,22 @@ impl<'a> Iterator for Iter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        panic!("Should never be called (roaring::Iter caches the size_hint itself)")
+        match self {
+            Iter::Array(inner) => inner.size_hint(),
+            Iter::Vec(inner) => inner.size_hint(),
+            Iter::BitmapBorrowed(inner) => inner.size_hint(),
+            Iter::BitmapOwned(inner) => inner.size_hint(),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {
+    fn len(&self) -> usize {
+        match self {
+            Iter::Array(inner) => inner.len(),
+            Iter::Vec(inner) => inner.len(),
+            Iter::BitmapBorrowed(inner) => inner.len(),
+            Iter::BitmapOwned(inner) => inner.len(),
+        }
     }
 }

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -95,6 +95,13 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
+impl ExactSizeIterator for Iter<'_> {
+    fn len(&self) -> usize {
+        self.size_hint as usize
+    }
+}
+
 impl Iterator for IntoIter {
     type Item = u64;
 
@@ -109,6 +116,13 @@ impl Iterator for IntoIter {
         } else {
             (usize::MAX, None)
         }
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl ExactSizeIterator for IntoIter {
+    fn len(&self) -> usize {
+        self.size_hint as usize
     }
 }
 


### PR DESCRIPTION
This is a blocker for #140 as proptest calls `size_hint` when generate / shrinking.

Could only implement ExactSizeIterator on the outer (Bit|Tree)Maps on 64 bit architectures to ensure the `u64` value is not truncated when casting to usize.