### PR TITLE
change opt-level to 2 in test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ retain_mut = "0.1.4"
 
 [dev-dependencies]
 proptest = { version = "1.0.0" }
+
+[profile.test]
+opt-level = 2


### PR DESCRIPTION
I've been using this on my local for awhile to speed up tests. It will require to rebuild the universe the first test run. I'm curious how it will affect CI builds.