### PR TITLE
Enable warnings for unsafe_op_in_unsafe_fn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0
+          - 1.56.1
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "roaring"
 version = "0.8.1"
-rust = "1.51.0"
+rust = "1.56.1"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "https://roaringbitmap.org: A better compressed bitset - pure Rust implementation"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 #![warn(missing_docs)]
+#![warn(unsafe_op_in_unsafe_fn)]
 #![warn(variant_size_differences)]
 #![allow(unknown_lints)] // For clippy
 


### PR DESCRIPTION
This PR will remove the implicit unsafe block from unsafe functions, requiring the use of unsafe code to be explicit. This is likely to become a warning by default, and possible an error in a future rust edition.

### Motivation:

None of our code fails this warning now. Let's keep it that way.

> `unsafe {}` blocks are about _discharging_ obligations, but `unsafe fn` are about _defining_ obligations. The fact that the body of an `unsafe fn` is also implicitly treated like a block has made it hard to realize this duality even for experienced Rust developers. (Completing the picture, `unsafe Trait` also defines an obligation, that is discharged by `unsafe impl`. Curiously, `unsafe trait` does not implicitly make all bodies of default functions defined inside this trait unsafe blocks, which is somewhat inconsistent with `unsafe fn` when viewed through this lens.)

[RFC 2585](https://rust-lang.github.io/rfcs/2585-unsafe-block-in-unsafe-fn.html)