### PR TITLE
Publish MSRV + verify with CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
+          - 1.51.0
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "roaring"
 version = "0.8.1"
+rust = "1.51.0"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "https://roaringbitmap.org: A better compressed bitset - pure Rust implementation"
 


### PR DESCRIPTION
This PR publishes the [Minimum Supported Rust Version](https://rust-lang.github.io/rfcs/2495-min-rust-version.html) and checks the MSRV in CI

Discovered with [`cargo msrv`](https://github.com/foresterre/cargo-msrv). For the curious, it's our dependency [retain_mut](https://crates.io/crates/retain_mut)'s usage of const_generics that makes it 1.51.0

### Motivation

User's should know what the min supported rust version of the lib is without having to build it. If we add code or a new dependency that increases the MSRV, it should require a version bump as it could be a breaking change. Therefore, we add the MSRV to our list of toolchains.