### PR TITLE
Reduce upper bound of keys in test bitmaps

### DIFF
--- a/src/bitmap/arbitrary.rs
+++ b/src/bitmap/arbitrary.rs
@@ -171,7 +171,8 @@ mod test {
 
     prop_compose! {
         fn containers(n: usize)
-                     (keys in ArrayStore::sampled(..=n, ..=u16::MAX as usize), stores in vec(Store::arbitrary(), n) ) -> RoaringBitmap {
+                     (keys in ArrayStore::sampled(..=n, ..=n as usize),
+                      stores in vec(Store::arbitrary(), n)) -> RoaringBitmap {
             let containers = keys.into_iter().zip(stores.into_iter()).map(|(key, store)| {
                 let mut container = Container { key, store };
                 container.ensure_correct_store();
@@ -183,7 +184,7 @@ mod test {
 
     impl RoaringBitmap {
         prop_compose! {
-            pub fn arbitrary()(bitmap in (0usize..=5).prop_flat_map(containers)) -> RoaringBitmap {
+            pub fn arbitrary()(bitmap in (0usize..=16).prop_flat_map(containers)) -> RoaringBitmap {
                 bitmap
             }
         }


### PR DESCRIPTION
Generating bitmaps with containers with keys in the bounds `..=u16::MAX` resulted in many disjoint bitmaps.

This limits the upper key bounds to the number of containers.

Also sneakily increases container count to 16 🥷