### PR TITLE
Fixup: allow lint rules for old linters

### DIFF
--- a/src/bitmap/store/array_store/mod.rs
+++ b/src/bitmap/store/array_store/mod.rs
@@ -309,6 +309,7 @@ impl BitAnd<Self> for &ArrayStore {
 }
 
 impl BitAndAssign<&Self> for ArrayStore {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn bitand_assign(&mut self, rhs: &Self) {
         let mut i = 0;
         self.vec.retain(|x| {

--- a/src/bitmap/store/bitmap_store.rs
+++ b/src/bitmap/store/bitmap_store.rs
@@ -354,12 +354,14 @@ impl BitAndAssign<&Self> for BitmapStore {
 }
 
 impl SubAssign<&Self> for BitmapStore {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn sub_assign(&mut self, rhs: &Self) {
         op_bitmaps(self, rhs, |l, r| *l &= !r);
     }
 }
 
 impl SubAssign<&ArrayStore> for BitmapStore {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn sub_assign(&mut self, rhs: &ArrayStore) {
         for &index in rhs.iter() {
             let (key, bit) = (key(index), bit(index));


### PR DESCRIPTION
Allow for false positive lint matches that warn on MSRV builds