### PR TITLE
allow lint rule to build in MSRV

### DIFF
--- a/src/bitmap/store/array_store/mod.rs
+++ b/src/bitmap/store/array_store/mod.rs
@@ -286,6 +286,7 @@ impl Sub<Self> for &ArrayStore {
 }
 
 impl SubAssign<&Self> for ArrayStore {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn sub_assign(&mut self, rhs: &Self) {
         let mut i = 0;
         self.vec.retain(|x| {


### PR DESCRIPTION
```sh
cargo +1.51.0 fmt
cargo +1.51.0 fmt --manifest-path benchmarks/Cargo.toml
cargo +1.51.0 clippy --all-targets  -- -D warnings
```

This should be the last one. 🤞 The above passes on my local machine with this change.