### PR TITLE
add PR hook to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - staging
       - trying
+  pull_request:
+    branches:
+      - master
 
 name: Continuous integration
 


### PR DESCRIPTION
Is there a reason we dont already do this? It would help me to know if a PR is green on CI before review process even starts.