### PR TITLE
Workaround for needless borrow lint

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -222,7 +222,8 @@ impl<'a> IntoIterator for &'a Container {
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Iter<'a> {
-        Iter { key: self.key, inner: (&self.store).into_iter() }
+        let store: &Store = &self.store;
+        Iter { key: self.key, inner: store.into_iter() }
     }
 }
 


### PR DESCRIPTION
Fix warning caused by differences in nightly and stable clippy lints.

This will fix the build, but I think we should be asking ourselves if we really want to checking formatting and lints with every toolchain. Fixing a warning in stable might trigger another in nightly.