### PR TITLE
Change Cargo.toml field to "rust-version"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "roaring"
 version = "0.8.1"
-rust = "1.56.1"
+rust-version = "1.56.1"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "https://roaringbitmap.org: A better compressed bitset - pure Rust implementation"
 


### PR DESCRIPTION
I believe this field is supposed to be "rust-version" instead of just "rust".