### PR TITLE
Add select impl and tests for RoaringTreemap

### DIFF
--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -303,6 +303,37 @@ impl RoaringTreemap {
             .unwrap_or(0)
             + iter.map(|(_, bitmap)| bitmap.len()).sum::<u64>()
     }
+
+    /// Returns the nth integer in the treemap (if the set is non-empty)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringTreemap;
+    ///
+    /// let mut rb = RoaringTreemap::new();
+    /// assert_eq!(rb.select(0), None);
+    ///
+    /// rb.insert(0);
+    /// rb.insert(10);
+    /// rb.insert(100);
+    ///
+    /// assert_eq!(rb.select(0), Some(0));
+    /// assert_eq!(rb.select(1), Some(10));
+    /// assert_eq!(rb.select(2), Some(100));
+    /// assert_eq!(rb.select(3), None);
+    /// ```
+    pub fn select(&self, mut n: u64) -> Option<u64> {
+        for (&key, bitmap) in &self.map {
+            let len = bitmap.len();
+            if len > n {
+                return Some((key as u64) << 32 | bitmap.select(n as u32).unwrap() as u64);
+            }
+            n -= len;
+        }
+
+        None
+    }
 }
 
 impl Default for RoaringTreemap {

--- a/tests/treemap_select.rs
+++ b/tests/treemap_select.rs
@@ -1,0 +1,44 @@
+extern crate roaring;
+
+use proptest::collection::btree_set;
+use proptest::prelude::*;
+use roaring::RoaringTreemap;
+
+#[test]
+fn select() {
+    let bitmap = (0..2000).collect::<RoaringTreemap>();
+
+    assert_eq!(bitmap.select(0), Some(0));
+}
+
+#[test]
+fn select_multiple_bitmap() {
+    let mut bitmap = (0..100_000).collect::<RoaringTreemap>();
+    bitmap.append(u32::MAX as u64..u32::MAX as u64 + 100_000).expect("sorted integers");
+
+    assert_eq!(bitmap.select(0), Some(0));
+    assert_eq!(bitmap.select(99_999), Some(99_999));
+    assert_eq!(bitmap.select(100_000), Some(u32::MAX as u64));
+    assert_eq!(bitmap.select(199_999), Some(u32::MAX as u64 + 99_999));
+    assert_eq!(bitmap.select(200_000), None);
+    assert_eq!(bitmap.select(u64::MAX), None);
+}
+
+#[test]
+fn select_empty() {
+    let bitmap = RoaringTreemap::new();
+
+    assert_eq!(bitmap.select(0), None);
+    assert_eq!(bitmap.select(1024), None);
+    assert_eq!(bitmap.select(u64::MAX), None);
+}
+
+proptest! {
+    #[test]
+    fn proptest_select(values in btree_set(any::<u64>(), 1000)) {
+        let bitmap = RoaringTreemap::from_sorted_iter(values.iter().cloned()).unwrap();
+        for (i, value) in values.iter().cloned().enumerate() {
+            prop_assert_eq!(bitmap.select(i as u64), Some(value));
+        }
+    }
+}


### PR DESCRIPTION
Implements `select` for `RoaringTreemap`

See #135 

Needs benchmarks before #135 can be closed