### PR TITLE
Swap SIMD merge implementation for bitonic merge

### DIFF
--- a/src/bitmap/store/array_store/vector.rs
+++ b/src/bitmap/store/array_store/vector.rs
@@ -502,12 +502,11 @@ where
         )
     }
 
-    let b = simd_swizzle!(b, [7, 6, 5, 4, 3, 2, 1, 0]);
-    let mut lo = lanes_min(a, b);
-    let mut hi = lanes_max(a, b);
-
-    lo = bitonic_merge(lo);
-    hi = bitonic_merge(hi);
+    let b_rev = simd_swizzle!(b, [7, 6, 5, 4, 3, 2, 1, 0]);
+    let min = lanes_min(a, b_rev);
+    let max = lanes_max(a, b_rev);
+    let lo = bitonic_merge(min);
+    let hi = bitonic_merge(max);
     [lo, hi]
 }
 


### PR DESCRIPTION
This is a more complex merge, but it removes data dependencies after the initial outer block:
```rust 
let b_rev = simd_swizzle!(b, [7, 6, 5, 4, 3, 2, 1, 0]);
let min = lanes_min(a, b);
let max = lanes_max(a, b);
```

Then in the succeeding block:

```rust
let lo = bitonic_merge(min);
let hi = bitonic_merge(max);
```

The more expensive computations for `lo` and `hi` can be processed independently. On modern superscalar processors this should happen in parallel, resulting in a net performance gain.