### PR TITLE
Bump the version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roaring"
-version = "0.8.1"
+version = "0.9.0"
 rust-version = "1.56.1"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "https://roaringbitmap.org: A better compressed bitset - pure Rust implementation"


### PR DESCRIPTION
The release notes are available in #178 and will be added to the GitHub release, thank you @saik0 for the notes again!