### PR TITLE
Remove the portable-simd unpublished crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ license = "MIT OR Apache-2.0"
 bytemuck = "1.7.3"
 byteorder = "1.4.3"
 retain_mut = "0.1.6"
-simd = { git = "https://github.com/rust-lang/portable-simd", package = "core_simd", optional = true }
+
+[features]
+# Enables SIMD-based algorithm that are most of the time faster than the
+# scalar ones. This feature can only be enabled on the nightly channel.
+simd = []
 
 [dev-dependencies]
 proptest = { version = "1.0.0" }

--- a/src/bitmap/store/array_store/vector.rs
+++ b/src/bitmap/store/array_store/vector.rs
@@ -11,7 +11,9 @@
 #![cfg(feature = "simd")]
 
 use super::scalar;
-use simd::{mask16x8, simd_swizzle, u16x8, LaneCount, Mask, Simd, SimdElement, SupportedLaneCount};
+use core::simd::{
+    mask16x8, simd_swizzle, u16x8, LaneCount, Mask, Simd, SimdElement, SupportedLaneCount,
+};
 
 // a one-pass SSE union algorithm
 pub fn or(lhs: &[u16], rhs: &[u16], visitor: &mut impl BinaryOperationVisitor) {
@@ -442,7 +444,7 @@ where
 }
 
 use crate::bitmap::store::array_store::visitor::BinaryOperationVisitor;
-use simd::{Swizzle2, Which, Which::First as A, Which::Second as B};
+use core::simd::{Swizzle2, Which, Which::First as A, Which::Second as B};
 
 /// Append to vectors to an imaginary 16 lane vector,  shift the lanes right by 1, then
 /// truncate to the low order 8 lanes

--- a/src/bitmap/store/array_store/visitor.rs
+++ b/src/bitmap/store/array_store/visitor.rs
@@ -10,7 +10,7 @@ use crate::bitmap::store::array_store::vector::swizzle_to_front;
 /// computing the cardinality of an operation without materializng a new bitmap.
 pub trait BinaryOperationVisitor {
     #[cfg(feature = "simd")]
-    fn visit_vector(&mut self, value: simd::u16x8, mask: u8);
+    fn visit_vector(&mut self, value: core::simd::u16x8, mask: u8);
     fn visit_scalar(&mut self, value: u16);
     fn visit_slice(&mut self, values: &[u16]);
 }
@@ -37,7 +37,7 @@ impl VecWriter {
 
 impl BinaryOperationVisitor for VecWriter {
     #[cfg(feature = "simd")]
-    fn visit_vector(&mut self, value: simd::u16x8, mask: u8) {
+    fn visit_vector(&mut self, value: core::simd::u16x8, mask: u8) {
         let result = swizzle_to_front(value, mask);
 
         // This idiom is better than subslicing result, as it compiles down to an unaligned vector
@@ -75,7 +75,7 @@ impl CardinalityCounter {
 
 impl BinaryOperationVisitor for CardinalityCounter {
     #[cfg(feature = "simd")]
-    fn visit_vector(&mut self, _value: simd::u16x8, mask: u8) {
+    fn visit_vector(&mut self, _value: core::simd::u16x8, mask: u8) {
         self.count += mask.count_ones() as usize;
     }
 


### PR DESCRIPTION
In order to be able to publish the v0.9.0 on crates.io, a crate must have all its dependencies available on crates.io. Unfortunately, the _portable-simd_ crate is not published but is part of [the _core_ library](https://doc.rust-lang.org/nightly/core/simd), we can try to use this instead.

I am encountering only one final issue with the above-defined library switch. The [`Mask<i16, 8_usize>::to_bitmask`](https://github.com/rust-lang/portable-simd/blob/78a18c3433c13bbd6259242185667c385eafe859/crates/core_simd/src/masks.rs#L228-L234) doesn't exist in the _core_ library. I must find a way to reproduce the behavior of `mask.to_bitmask()[0]` as we only need that.

The internal implementations of the `to_bitmask` method do [not look too complex](https://github.com/rust-lang/portable-simd/blob/78a18c3433c13bbd6259242185667c385eafe859/crates/core_simd/src/masks.rs#L5-L13):
 - [The generic impl](https://github.com/rust-lang/portable-simd/blob/78a18c3433c13bbd6259242185667c385eafe859/crates/core_simd/src/masks/full_masks.rs#L113-L132).
 - [The _x86_64_ impl](https://github.com/rust-lang/portable-simd/blob/78a18c3433c13bbd6259242185667c385eafe859/crates/core_simd/src/masks/bitmask.rs#L118-L124).