### PR TITLE
Optimize insert_range for large ranges

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -40,6 +40,12 @@ impl Container {
     }
 
     pub fn insert_range(&mut self, range: RangeInclusive<u16>) -> u64 {
+        // If inserting the range will make this a bitmap by itself, do it now
+        if range.len() as u64 > ARRAY_LIMIT {
+            if let Store::Array(arr) = &self.store {
+                self.store = Store::Bitmap(arr.to_bitmap_store());
+            }
+        }
         let inserted = self.store.insert_range(range);
         self.ensure_correct_store();
         inserted


### PR DESCRIPTION
In the case where we're inserting enough that we know it will end up too large to store as an array, convert to a bitmap before adding the range

This leads to some quite large speed ups for large range insertions:

```
insert_range/from_empty_20000
                        time:   [226.64 ns 226.89 ns 227.16 ns]
                        thrpt:  [88.042 Gelem/s 88.147 Gelem/s 88.245 Gelem/s]
                 change:
                        time:   [-99.517% -99.516% -99.514%] (p = 0.00 < 0.05)
                        thrpt:  [+20484% +20547% +20612%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  4 (4.00%) high severe
```