### PR TITLE
Fix the benchmarks datasets URL format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/proptest-regressions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bytemuck = "1.7.3"
 byteorder = "1.4.3"
-retain_mut = "0.1.6"
+retain_mut = "=0.1.7"
 
 [features]
 simd = []

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ roaring = { path = ".." }
 
 [dev-dependencies]
 once_cell = "1.9"
-git2 = { version = "0.13", default-features = false, features = ["vendored-openssl"] }
+git2 = { version = "0.13", default-features = false, features = ["https", "vendored-openssl"] }
 zip = { version = "0.5", default-features = false, features = ["deflate"] }
 indicatif = "0.16"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/benchmarks/benches/datasets.rs
+++ b/benchmarks/benches/datasets.rs
@@ -99,7 +99,7 @@ fn init_datasets() -> Result<PathBuf, Box<dyn std::error::Error>> {
     if !Path::new(&repo_path).exists() {
         git2::build::RepoBuilder::new()
             .fetch_options(fetch_opts)
-            .clone("git://github.com/RoaringBitmap/real-roaring-datasets.git", &repo_path)?;
+            .clone("https://github.com/RoaringBitmap/real-roaring-datasets.git", &repo_path)?;
     } else {
         let repo = git2::Repository::open(&repo_path)?;
         repo.find_remote("origin")?.fetch(&["master"], Some(&mut fetch_opts), None)?;


### PR DESCRIPTION
We were using an URL of the form _git://github.com/orga/repo.git_ which is wrong and GitHub broke it recently. I just changed it to make it valid by using the https://github.com/orga/repo.git format.

This PR also changes the version of `retain_mut` to _=0.1.7_ to avoid CI-breaking warnings. If you want to understand the reason why I am doing that you can read more in #224.