### PR TITLE
Fix range_checks proptest

### DIFF
--- a/tests/range_checks.rs
+++ b/tests/range_checks.rs
@@ -1,5 +1,5 @@
 use proptest::array::uniform2;
-use proptest::collection::vec;
+use proptest::collection::hash_set;
 use proptest::prelude::*;
 use roaring::RoaringBitmap;
 
@@ -7,7 +7,7 @@ proptest! {
     #[test]
     fn proptest_range(
         range in uniform2(..=262_143_u32),
-        extra in vec(..=262_143_u32, ..=100),
+        extra in hash_set(..=262_143_u32, ..=100),
     ){
         let range = range[0]..range[1];
         let mut bitmap = RoaringBitmap::new();


### PR DESCRIPTION
If there were duplicate values in the extra list to remove, removing
multiple instances of the same number would _not_ decrease the
range_cardinality, since the value was already removed. Changed to
expect a set of extra values, rather than a vec

Fixes #238 