### PR TITLE
More off-by-one errors in bitmap contains_range

### DIFF
--- a/src/bitmap/store/bitmap_store.rs
+++ b/src/bitmap/store/bitmap_store.rs
@@ -192,8 +192,15 @@ impl BitmapStore {
         let (start_i, start_bit) = (key(start), bit(start));
         let (end_i, end_bit) = (key(end), bit(end));
 
+        // Create a mask to exclude the first `start_bit` bits
+        // e.g. if we start at bit index 1, this will create a mask which includes all but the bit
+        // at index 0.
         let start_mask = !((1 << start_bit) - 1);
-        let end_mask = (1 << end_bit) - 1;
+        // We want to create a mask which includes the end_bit, so we create a mask of
+        // `end_bit + 1` bits. `end_bit` will be between [0, 63], so we create a mask including
+        // between [1, 64] bits. For example, if the last bit is the 0th bit, we make a mask with
+        // only the 0th bit set (one bit).
+        let end_mask = (!0) >> (64 - (end_bit + 1));
 
         match &self.bits[start_i..=end_i] {
             [] => unreachable!(),

--- a/tests/range_checks.rs
+++ b/tests/range_checks.rs
@@ -1,30 +1,77 @@
-use proptest::array::uniform2;
 use proptest::collection::hash_set;
 use proptest::prelude::*;
 use roaring::RoaringBitmap;
 
+#[test]
+fn u32_max() {
+    let mut bitmap = RoaringBitmap::new();
+    bitmap.insert(u32::MAX);
+    assert!(bitmap.contains_range(u32::MAX..=u32::MAX));
+    assert!(!bitmap.contains_range(u32::MAX - 1..=u32::MAX));
+
+    bitmap.insert_range(4_000_000_000..);
+    assert!(bitmap.contains_range(4_000_000_000..));
+    assert!(bitmap.contains_range(4_000_000_000..u32::MAX));
+    assert!(bitmap.contains_range(4_000_000_000..=u32::MAX));
+    assert!(bitmap.contains_range(4_100_000_000..=u32::MAX));
+}
+
 proptest! {
     #[test]
     fn proptest_range(
-        range in uniform2(..=262_143_u32),
-        extra in hash_set(..=262_143_u32, ..=100),
+        start in ..=262_143_u32,
+        len in ..=262_143_u32,
+        extra in hash_set(..=462_143_u32, ..=100),
     ){
-        let range = range[0]..range[1];
+        let end = start + len;
+        let range = start..end;
+        let inverse_empty_range = (start+len)..start;
+
         let mut bitmap = RoaringBitmap::new();
         bitmap.insert_range(range.clone());
         assert!(bitmap.contains_range(range.clone()));
+        assert!(bitmap.contains_range(inverse_empty_range.clone()));
         assert_eq!(bitmap.range_cardinality(range.clone()) as usize, range.len());
 
         for &val in &extra {
             bitmap.insert(val);
             assert!(bitmap.contains_range(range.clone()));
+            assert!(bitmap.contains_range(inverse_empty_range.clone()));
             assert_eq!(bitmap.range_cardinality(range.clone()) as usize, range.len());
         }
 
         for (i, &val) in extra.iter().filter(|x| range.contains(x)).enumerate() {
             bitmap.remove(val);
             assert!(!bitmap.contains_range(range.clone()));
+            assert!(bitmap.contains_range(inverse_empty_range.clone()));
             assert_eq!(bitmap.range_cardinality(range.clone()) as usize, range.len() - i - 1);
         }
+    }
+
+    #[test]
+    fn proptest_range_boundaries(
+        // Ensure we can always subtract one from start
+        start in 1..=262_143_u32,
+        len in 0..=262_143_u32,
+    ) {
+        let mut bitmap = RoaringBitmap::new();
+        let end = start + len;
+        let half = start + len / 2;
+        bitmap.insert_range(start..end);
+
+        assert!(bitmap.contains_range(start..end));
+
+        assert!(bitmap.contains_range(start+1..end));
+        assert!(bitmap.contains_range(start..end - 1));
+        assert!(bitmap.contains_range(start+1..end - 1));
+
+        assert!(!bitmap.contains_range(start - 1..end));
+        assert!(!bitmap.contains_range(start - 1..end - 1));
+        assert!(!bitmap.contains_range(start..end + 1));
+        assert!(!bitmap.contains_range(start + 1..end + 1));
+        assert!(!bitmap.contains_range(start - 1..end + 1));
+
+        assert!(!bitmap.contains_range(start - 1..half));
+        assert!(!bitmap.contains_range(half..end + 1));
     }
 }


### PR DESCRIPTION
The CRoaring code uses an exclusive u32 range for the implementaiton of
a bitset container's `contains_range` function.

Had to think a bit about the best way to make it work, if you can think of a prettier way to write any of it, let me know.

Fixes #238 