### PR TITLE
Bump Rust version to 1.65 and remove Bors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.56.1
+          - 1.65.0
     env:
       RUSTFLAGS: "-C target-cpu=native -C opt-level=3"
       ROARINGRS_BENCH_OFFLINE: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
       - trying
   pull_request:
     branches:
-      - master
+      - main
 
 name: Continuous integration
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.139", optional = true }
 simd = []
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.2.0"
 serde_json = "1.0.85"
 bincode = "1.3.3"
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ roaring = { path = ".." }
 
 [dev-dependencies]
 once_cell = "1.9"
-git2 = { version = "0.13", default-features = false, features = ["https", "vendored-openssl"] }
+git2 = { version = "0.17", default-features = false, features = ["https", "vendored-openssl"] }
 zip = { version = "0.5", default-features = false, features = ["deflate"] }
 indicatif = "0.16"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,0 @@
-status = ["ci (stable)"]
-# 4 hours timeout
-timeout-sec = 14400

--- a/src/bitmap/arbitrary.rs
+++ b/src/bitmap/arbitrary.rs
@@ -173,7 +173,7 @@ mod test {
         fn containers(n: usize)
                      (keys in ArrayStore::sampled(..=n, ..=n),
                       stores in vec(Store::arbitrary(), n)) -> RoaringBitmap {
-            let containers = keys.into_iter().zip(stores.into_iter()).map(|(key, store)| {
+            let containers = keys.into_iter().zip(stores).map(|(key, store)| {
                 let mut container = Container { key, store };
                 container.ensure_correct_store();
                 container

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -133,7 +133,7 @@ impl IntoIterator for RoaringBitmap {
 
 impl<const N: usize> From<[u32; N]> for RoaringBitmap {
     fn from(arr: [u32; N]) -> Self {
-        RoaringBitmap::from_iter(arr.into_iter())
+        RoaringBitmap::from_iter(arr)
     }
 }
 

--- a/src/bitmap/multiops.rs
+++ b/src/bitmap/multiops.rs
@@ -125,7 +125,7 @@ fn try_multi_and_owned<E>(
     let mut start = start.into_iter();
 
     if let Some(mut lhs) = start.next() {
-        for rhs in start.into_iter().map(Ok).chain(iter) {
+        for rhs in start.map(Ok).chain(iter) {
             if lhs.is_empty() {
                 return Ok(lhs);
             }
@@ -151,7 +151,7 @@ fn try_multi_and_ref<'a, E>(
     let mut start = start.into_iter();
 
     if let Some(mut lhs) = start.next().cloned() {
-        for rhs in start.into_iter().map(Ok).chain(iter) {
+        for rhs in start.map(Ok).chain(iter) {
             if lhs.is_empty() {
                 return Ok(lhs);
             }
@@ -225,7 +225,7 @@ fn try_multi_or_owned<E>(
         return Ok(RoaringBitmap::new());
     };
 
-    for bitmap in start.into_iter().map(Ok).chain(iter) {
+    for bitmap in start.map(Ok).chain(iter) {
         merge_container_owned(&mut containers, bitmap?.containers, BitOrAssign::bitor_assign);
     }
 
@@ -323,7 +323,7 @@ fn try_multi_or_ref<'a, E: 'a>(
     };
 
     // Phase 2: Operate on the remaining containers
-    for bitmap in start.into_iter().map(Ok).chain(iter) {
+    for bitmap in start.map(Ok).chain(iter) {
         merge_container_ref(&mut containers, &bitmap?.containers, |a, b| *a |= b);
     }
 

--- a/src/bitmap/proptests.rs
+++ b/src/bitmap/proptests.rs
@@ -399,6 +399,7 @@ mod test {
         fn the_empty_set_is_the_identity_for_union(a in RoaringBitmap::arbitrary()) {
             prop_assert_eq!(&(&a | &empty_set()), &a);
 
+            #[allow(clippy::redundant_clone)]
             { // op_assign_ref
                 let mut x = a.clone();
                 x |= &empty_set();
@@ -419,6 +420,7 @@ mod test {
         fn the_empty_set_is_the_identity_for_symmetric_difference(a in RoaringBitmap::arbitrary()) {
             prop_assert_eq!(&(&a ^ &empty_set()), &a);
 
+            #[allow(clippy::redundant_clone)]
             { // op_assign_ref
                 let mut x = a.clone();
                 x ^= &empty_set();

--- a/src/bitmap/store/mod.rs
+++ b/src/bitmap/store/mod.rs
@@ -196,7 +196,7 @@ impl BitOr<&Store> for &Store {
 
     fn bitor(self, rhs: &Store) -> Store {
         match (self, rhs) {
-            (&Array(ref vec1), &Array(ref vec2)) => Array(BitOr::bitor(vec1, vec2)),
+            (Array(vec1), Array(vec2)) => Array(BitOr::bitor(vec1, vec2)),
             (&Bitmap(..), &Array(..)) => {
                 let mut lhs = self.clone();
                 BitOrAssign::bitor_assign(&mut lhs, rhs);
@@ -239,17 +239,17 @@ impl BitOrAssign<Store> for Store {
 impl BitOrAssign<&Store> for Store {
     fn bitor_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
-            (&mut Array(ref mut vec1), &Array(ref vec2)) => {
+            (&mut Array(ref mut vec1), Array(vec2)) => {
                 let this = mem::take(vec1);
                 *vec1 = BitOr::bitor(&this, vec2);
             }
-            (&mut Bitmap(ref mut bits1), &Array(ref vec2)) => {
+            (&mut Bitmap(ref mut bits1), Array(vec2)) => {
                 BitOrAssign::bitor_assign(bits1, vec2);
             }
-            (&mut Bitmap(ref mut bits1), &Bitmap(ref bits2)) => {
+            (&mut Bitmap(ref mut bits1), Bitmap(bits2)) => {
                 BitOrAssign::bitor_assign(bits1, bits2);
             }
-            (this @ &mut Array(..), &Bitmap(ref bits2)) => {
+            (this @ &mut Array(..), Bitmap(bits2)) => {
                 let mut lhs: Store = Bitmap(bits2.clone());
                 BitOrAssign::bitor_assign(&mut lhs, &*this);
                 *this = lhs;
@@ -263,7 +263,7 @@ impl BitAnd<&Store> for &Store {
 
     fn bitand(self, rhs: &Store) -> Store {
         match (self, rhs) {
-            (&Array(ref vec1), &Array(ref vec2)) => Array(BitAnd::bitand(vec1, vec2)),
+            (Array(vec1), Array(vec2)) => Array(BitAnd::bitand(vec1, vec2)),
             (&Bitmap(..), &Array(..)) => {
                 let mut rhs = rhs.clone();
                 BitAndAssign::bitand_assign(&mut rhs, self);
@@ -306,7 +306,7 @@ impl BitAndAssign<&Store> for Store {
     #[allow(clippy::suspicious_op_assign_impl)]
     fn bitand_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
-            (&mut Array(ref mut vec1), &Array(ref vec2)) => {
+            (&mut Array(ref mut vec1), Array(vec2)) => {
                 let (mut lhs, rhs) = if vec2.len() < vec1.len() {
                     (vec2.clone(), &*vec1)
                 } else {
@@ -316,10 +316,10 @@ impl BitAndAssign<&Store> for Store {
                 BitAndAssign::bitand_assign(&mut lhs, rhs);
                 *vec1 = lhs;
             }
-            (&mut Bitmap(ref mut bits1), &Bitmap(ref bits2)) => {
+            (&mut Bitmap(ref mut bits1), Bitmap(bits2)) => {
                 BitAndAssign::bitand_assign(bits1, bits2);
             }
-            (&mut Array(ref mut vec1), &Bitmap(ref bits2)) => {
+            (&mut Array(ref mut vec1), Bitmap(bits2)) => {
                 BitAndAssign::bitand_assign(vec1, bits2);
             }
             (this @ &mut Bitmap(..), &Array(..)) => {
@@ -336,7 +336,7 @@ impl Sub<&Store> for &Store {
 
     fn sub(self, rhs: &Store) -> Store {
         match (self, rhs) {
-            (&Array(ref vec1), &Array(ref vec2)) => Array(Sub::sub(vec1, vec2)),
+            (Array(vec1), Array(vec2)) => Array(Sub::sub(vec1, vec2)),
             _ => {
                 let mut lhs = self.clone();
                 SubAssign::sub_assign(&mut lhs, rhs);
@@ -349,16 +349,16 @@ impl Sub<&Store> for &Store {
 impl SubAssign<&Store> for Store {
     fn sub_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
-            (&mut Array(ref mut vec1), &Array(ref vec2)) => {
+            (&mut Array(ref mut vec1), Array(vec2)) => {
                 SubAssign::sub_assign(vec1, vec2);
             }
-            (&mut Bitmap(ref mut bits1), &Array(ref vec2)) => {
+            (&mut Bitmap(ref mut bits1), Array(vec2)) => {
                 SubAssign::sub_assign(bits1, vec2);
             }
-            (&mut Bitmap(ref mut bits1), &Bitmap(ref bits2)) => {
+            (&mut Bitmap(ref mut bits1), Bitmap(bits2)) => {
                 SubAssign::sub_assign(bits1, bits2);
             }
-            (&mut Array(ref mut vec1), &Bitmap(ref bits2)) => {
+            (&mut Array(ref mut vec1), Bitmap(bits2)) => {
                 SubAssign::sub_assign(vec1, bits2);
             }
         }
@@ -370,7 +370,7 @@ impl BitXor<&Store> for &Store {
 
     fn bitxor(self, rhs: &Store) -> Store {
         match (self, rhs) {
-            (&Array(ref vec1), &Array(ref vec2)) => Array(BitXor::bitxor(vec1, vec2)),
+            (Array(vec1), Array(vec2)) => Array(BitXor::bitxor(vec1, vec2)),
             (&Array(..), &Bitmap(..)) => {
                 let mut lhs = rhs.clone();
                 BitXorAssign::bitxor_assign(&mut lhs, self);
@@ -408,17 +408,17 @@ impl BitXorAssign<Store> for Store {
 impl BitXorAssign<&Store> for Store {
     fn bitxor_assign(&mut self, rhs: &Store) {
         match (self, rhs) {
-            (&mut Array(ref mut vec1), &Array(ref vec2)) => {
+            (&mut Array(ref mut vec1), Array(vec2)) => {
                 let this = mem::take(vec1);
                 *vec1 = BitXor::bitxor(&this, vec2);
             }
-            (&mut Bitmap(ref mut bits1), &Array(ref vec2)) => {
+            (&mut Bitmap(ref mut bits1), Array(vec2)) => {
                 BitXorAssign::bitxor_assign(bits1, vec2);
             }
-            (&mut Bitmap(ref mut bits1), &Bitmap(ref bits2)) => {
+            (&mut Bitmap(ref mut bits1), Bitmap(bits2)) => {
                 BitXorAssign::bitxor_assign(bits1, bits2);
             }
-            (this @ &mut Array(..), &Bitmap(ref bits2)) => {
+            (this @ &mut Array(..), Bitmap(bits2)) => {
                 let mut lhs: Store = Bitmap(bits2.clone());
                 BitXorAssign::bitxor_assign(&mut lhs, &*this);
                 *this = lhs;

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -232,7 +232,7 @@ impl IntoIterator for RoaringTreemap {
 
 impl<const N: usize> From<[u64; N]> for RoaringTreemap {
     fn from(arr: [u64; N]) -> Self {
-        RoaringTreemap::from_iter(arr.into_iter())
+        RoaringTreemap::from_iter(arr)
     }
 }
 

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -2,6 +2,7 @@ extern crate roaring;
 use roaring::RoaringBitmap;
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn array() {
     let original = (0..2000).collect::<RoaringBitmap>();
     let clone = original.clone();
@@ -10,6 +11,7 @@ fn array() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn bitmap() {
     let original = (0..6000).collect::<RoaringBitmap>();
     let clone = original.clone();
@@ -18,6 +20,7 @@ fn bitmap() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn arrays() {
     let original = (0..2000)
         .chain(1_000_000..1_002_000)
@@ -29,6 +32,7 @@ fn arrays() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn bitmaps() {
     let original = (0..6000)
         .chain(1_000_000..1_012_000)

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -64,7 +64,7 @@ proptest! {
     fn iter(values in btree_set(any::<u32>(), ..=10_000)) {
         let bitmap = RoaringBitmap::from_sorted_iter(values.iter().cloned()).unwrap();
         // Iterator::eq != PartialEq::eq - cannot use assert_eq macro
-        assert!(values.into_iter().eq(bitmap.into_iter()));
+        assert!(values.into_iter().eq(bitmap));
     }
 }
 
@@ -99,7 +99,7 @@ fn from_iter() {
     // with u32 as well as &u32 elements.
     let vals = vec![1, 5, 10000];
     let a = RoaringBitmap::from_iter(vals.iter());
-    let b = RoaringBitmap::from_iter(vals.into_iter());
+    let b = RoaringBitmap::from_iter(vals);
     assert_eq!(a, b);
 }
 
@@ -131,7 +131,7 @@ where
 #[test]
 fn outside_in_iterator() {
     let values = 0..10;
-    assert!(outside_in(values).eq(vec![0, 9, 1, 8, 2, 7, 3, 6, 4, 5].into_iter()));
+    assert!(outside_in(values).eq(vec![0, 9, 1, 8, 2, 7, 3, 6, 4, 5]));
 }
 
 #[test]

--- a/tests/treemap_clone.rs
+++ b/tests/treemap_clone.rs
@@ -2,6 +2,7 @@ extern crate roaring;
 use roaring::RoaringTreemap;
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn array() {
     let original = (0..2000).collect::<RoaringTreemap>();
     let clone = original.clone();
@@ -10,6 +11,7 @@ fn array() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn bitmap() {
     let original = (0..6000).collect::<RoaringTreemap>();
     let clone = original.clone();
@@ -18,6 +20,7 @@ fn bitmap() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn arrays() {
     let original = ((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000))
         .collect::<RoaringTreemap>();
@@ -27,6 +30,7 @@ fn arrays() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn bitmaps() {
     let original = ((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000))
         .collect::<RoaringTreemap>();

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -74,7 +74,7 @@ proptest! {
     fn iter(values in btree_set(any::<u64>(), ..=10_000)) {
         let bitmap = RoaringTreemap::from_sorted_iter(values.iter().cloned()).unwrap();
 
-        assert!(values.into_iter().eq(bitmap.into_iter()));
+        assert!(values.into_iter().eq(bitmap));
     }
 }
 
@@ -104,7 +104,7 @@ fn from_iter() {
     // with u64 as well as &u64 elements.
     let vals = vec![1, 5, 1_000_000_000_000_000];
     let a = RoaringTreemap::from_iter(vals.iter());
-    let b = RoaringTreemap::from_iter(vals.into_iter());
+    let b = RoaringTreemap::from_iter(vals);
     assert_eq!(a, b);
 }
 


### PR DESCRIPTION
This PR bumps the Rust version to 1.65.0 to ensure proptest v1.2.0 compiles (requires 1.60) an removes the requirement of bors to merge and test PRs.