### PR TITLE
Rename the `remove_front/back` methods into `remove_smallest/biggest`

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -94,7 +94,7 @@ impl Container {
         result
     }
 
-    pub fn remove_front(&mut self, n: u64) {
+    pub fn remove_smallest(&mut self, n: u64) {
         match &self.store {
             Store::Bitmap(bits) => {
                 if bits.len() - n <= ARRAY_LIMIT {
@@ -102,14 +102,14 @@ impl Container {
                     replace_array.extend(bits.iter().skip(n as usize));
                     self.store = Store::Array(store::ArrayStore::from_vec_unchecked(replace_array));
                 } else {
-                    self.store.remove_front(n)
+                    self.store.remove_smallest(n)
                 }
             }
-            Store::Array(_) => self.store.remove_front(n),
+            Store::Array(_) => self.store.remove_smallest(n),
         };
     }
 
-    pub fn remove_back(&mut self, n: u64) {
+    pub fn remove_biggest(&mut self, n: u64) {
         match &self.store {
             Store::Bitmap(bits) => {
                 if bits.len() - n <= ARRAY_LIMIT {
@@ -117,10 +117,10 @@ impl Container {
                     replace_array.extend(bits.iter().take((bits.len() - n) as usize));
                     self.store = Store::Array(store::ArrayStore::from_vec_unchecked(replace_array));
                 } else {
-                    self.store.remove_back(n)
+                    self.store.remove_biggest(n)
                 }
             }
-            Store::Array(_) => self.store.remove_back(n),
+            Store::Array(_) => self.store.remove_biggest(n),
         };
     }
 

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -579,7 +579,7 @@ impl RoaringBitmap {
         None
     }
 
-    /// Removes the specified number of elements from the top.
+    /// Removes the `n` smallests values from this bitmap.
     ///
     /// # Examples
     ///
@@ -587,13 +587,13 @@ impl RoaringBitmap {
     /// use roaring::RoaringBitmap;
     ///
     /// let mut rb = RoaringBitmap::from_iter([1, 5, 7, 9]);
-    /// rb.remove_front(2);
+    /// rb.remove_smallest(2);
     /// assert_eq!(rb, RoaringBitmap::from_iter([7, 9]));
     ///
     /// let mut rb = RoaringBitmap::from_iter([1, 3, 7, 9]);
-    /// rb.remove_front(2);
+    /// rb.remove_smallest(2);
     /// assert_eq!(rb, RoaringBitmap::from_iter([7, 9]));
-    pub fn remove_front(&mut self, mut n: u64) {
+    pub fn remove_smallest(&mut self, mut n: u64) {
         // remove containers up to the front of the target
         let position = self.containers.iter().position(|container| {
             let container_len = container.len();
@@ -611,11 +611,11 @@ impl RoaringBitmap {
         // remove data in containers if there are still targets for deletion
         if n > 0 && !self.containers.is_empty() {
             // container immediately before should have been deleted, so the target is 0 index
-            self.containers[0].remove_front(n);
+            self.containers[0].remove_smallest(n);
         }
     }
 
-    /// Removes the specified number of elements from the tail.
+    /// Removes the `n` biggests values from this bitmap.
     ///
     /// # Examples
     ///
@@ -623,11 +623,11 @@ impl RoaringBitmap {
     /// use roaring::RoaringBitmap;
     ///
     /// let mut rb = RoaringBitmap::from_iter([1, 5, 7, 9]);
-    /// rb.remove_back(2);
+    /// rb.remove_biggest(2);
     /// assert_eq!(rb, RoaringBitmap::from_iter([1, 5]));
-    /// rb.remove_back(1);
+    /// rb.remove_biggest(1);
     /// assert_eq!(rb, RoaringBitmap::from_iter([1]));
-    pub fn remove_back(&mut self, mut n: u64) {
+    pub fn remove_biggest(&mut self, mut n: u64) {
         // remove containers up to the back of the target
         let position = self.containers.iter().rposition(|container| {
             let container_len = container.len();
@@ -642,7 +642,7 @@ impl RoaringBitmap {
         if let Some(position) = position {
             self.containers.drain(position + 1..);
             if n > 0 && !self.containers.is_empty() {
-                self.containers[position].remove_back(n);
+                self.containers[position].remove_biggest(n);
             }
         } else {
             self.containers.clear();
@@ -800,59 +800,59 @@ mod tests {
     }
 
     #[test]
-    fn remove_front_for_vec() {
+    fn remove_smallest_for_vec() {
         let mut bitmap = RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]);
-        bitmap.remove_front(3);
+        bitmap.remove_smallest(3);
         assert_eq!(bitmap.len(), 3);
         assert_eq!(bitmap, RoaringBitmap::from_iter([7, 9, 11]));
 
         bitmap = RoaringBitmap::from_iter([1, 2, 5, 7, 9, 11]);
-        bitmap.remove_front(3);
+        bitmap.remove_smallest(3);
         assert_eq!(bitmap.len(), 3);
         assert_eq!(bitmap, RoaringBitmap::from_iter([7, 9, 11]));
 
         bitmap = RoaringBitmap::from_iter([1, 3]);
-        bitmap.remove_front(2);
+        bitmap.remove_smallest(2);
         assert_eq!(bitmap.len(), 0);
 
         bitmap = RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]);
-        bitmap.remove_front(0);
+        bitmap.remove_smallest(0);
         assert_eq!(bitmap.len(), 6);
         assert_eq!(bitmap, RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]));
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..(1_u32 << 16) + 5);
-        bitmap.remove_front(65537);
+        bitmap.remove_smallest(65537);
         assert_eq!(bitmap.len(), 4);
         assert_eq!(bitmap, RoaringBitmap::from_iter([65537, 65538, 65539, 65540]));
 
         bitmap = RoaringBitmap::from_iter([1, 2, 5, 7, 9, 11]);
-        bitmap.remove_front(7);
+        bitmap.remove_smallest(7);
         assert_eq!(bitmap, RoaringBitmap::default());
     }
 
     #[test]
-    fn remove_front_for_bit() {
+    fn remove_smallest_for_bit() {
         let mut bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..4098);
-        bitmap.remove_front(4095);
+        bitmap.remove_smallest(4095);
         assert_eq!(bitmap.len(), 3);
         // removed bit to vec
         assert_eq!(bitmap, RoaringBitmap::from_iter([4095, 4096, 4097]));
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..6000);
-        bitmap.remove_front(999);
+        bitmap.remove_smallest(999);
         assert_eq!(bitmap.len(), 5001);
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..8000);
-        bitmap.remove_front(10);
+        bitmap.remove_smallest(10);
         assert_eq!(bitmap.len(), 7990);
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..200000);
-        bitmap.remove_front(2000);
+        bitmap.remove_smallest(2000);
         assert_eq!(bitmap.len(), 198000);
         assert_eq!(bitmap, RoaringBitmap::from_iter(2000..200000));
 
@@ -860,67 +860,67 @@ mod tests {
         bitmap.insert_range(0..2);
         bitmap.insert_range(4..7);
         bitmap.insert_range(1000..6000);
-        bitmap.remove_front(30);
+        bitmap.remove_smallest(30);
         assert_eq!(bitmap.len(), 4975);
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..65535);
-        bitmap.remove_front(0);
+        bitmap.remove_smallest(0);
         assert_eq!(bitmap.len(), 65535);
     }
 
     #[test]
-    fn remove_back_for_bit() {
+    fn remove_biggest_for_bit() {
         let mut bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..5000);
-        bitmap.remove_back(1000);
+        bitmap.remove_biggest(1000);
         assert_eq!(bitmap.len(), 4000);
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..6000);
-        bitmap.remove_back(1000);
+        bitmap.remove_biggest(1000);
         assert_eq!(bitmap.len(), 5000);
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..200000);
-        bitmap.remove_back(196000);
+        bitmap.remove_biggest(196000);
         assert_eq!(bitmap.len(), 4000);
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..200000);
-        bitmap.remove_back(2000);
+        bitmap.remove_biggest(2000);
         assert_eq!(bitmap.len(), 198000);
         assert_eq!(bitmap, RoaringBitmap::from_iter(0..198000));
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..65535);
-        bitmap.remove_back(0);
+        bitmap.remove_biggest(0);
         assert_eq!(bitmap.len(), 65535);
     }
 
     #[test]
-    fn remove_back_for_vec() {
+    fn remove_biggest_for_vec() {
         let mut bitmap = RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]);
-        bitmap.remove_back(2);
+        bitmap.remove_biggest(2);
         assert_eq!(bitmap, RoaringBitmap::from_iter([1, 2, 3, 7]));
 
         bitmap = RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]);
-        bitmap.remove_back(6);
+        bitmap.remove_biggest(6);
         assert_eq!(bitmap.len(), 0);
 
         bitmap = RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]);
-        bitmap.remove_back(0);
+        bitmap.remove_biggest(0);
         assert_eq!(bitmap.len(), 6);
         assert_eq!(bitmap, RoaringBitmap::from_iter([1, 2, 3, 7, 9, 11]));
 
         bitmap = RoaringBitmap::new();
         bitmap.insert_range(0..(1_u32 << 16) + 5);
-        bitmap.remove_back(65537);
+        bitmap.remove_biggest(65537);
         assert_eq!(bitmap.len(), 4);
         assert_eq!(bitmap, RoaringBitmap::from_iter([0, 1, 2, 3]));
 
         let mut bitmap = RoaringBitmap::from_iter([1, 2, 3]);
-        bitmap.remove_back(4);
+        bitmap.remove_biggest(4);
         assert_eq!(bitmap, RoaringBitmap::default());
     }
 }

--- a/src/bitmap/store/array_store/mod.rs
+++ b/src/bitmap/store/array_store/mod.rs
@@ -110,12 +110,12 @@ impl ArrayStore {
         (pos_end - pos_start) as u64
     }
 
-    pub fn remove_front(&mut self, n: u64) {
+    pub fn remove_smallest(&mut self, n: u64) {
         self.vec.rotate_left(n as usize);
         self.vec.truncate(self.vec.len() - n as usize);
     }
 
-    pub fn remove_back(&mut self, n: u64) {
+    pub fn remove_biggest(&mut self, n: u64) {
         self.vec.truncate(self.vec.len() - n as usize);
     }
 
@@ -573,16 +573,16 @@ mod tests {
     }
 
     #[test]
-    fn test_bitmap_remove_front() {
+    fn test_bitmap_remove_smallest() {
         let mut store = Store::Array(ArrayStore::from_vec_unchecked(vec![1, 2, 130, 500]));
-        store.remove_front(3);
+        store.remove_smallest(3);
         assert_eq!(into_vec(store), vec![500]);
     }
 
     #[test]
-    fn test_bitmap_remove_back() {
+    fn test_bitmap_remove_biggest() {
         let mut store = Store::Array(ArrayStore::from_vec_unchecked(vec![1, 2, 130, 500]));
-        store.remove_back(2);
+        store.remove_biggest(2);
         assert_eq!(into_vec(store), vec![1, 2]);
     }
 }

--- a/src/bitmap/store/bitmap_store.rs
+++ b/src/bitmap/store/bitmap_store.rs
@@ -309,7 +309,7 @@ impl BitmapStore {
     }
 
     /// Set N bits that are currently 1 bit from the lower bit to 0.
-    pub fn remove_front(&mut self, mut clear_bits: u64) {
+    pub fn remove_smallest(&mut self, mut clear_bits: u64) {
         if self.len() < clear_bits {
             self.clear();
             return;
@@ -332,7 +332,7 @@ impl BitmapStore {
     }
 
     /// Set N bits that are currently 1 bit from the lower bit to 0.
-    pub fn remove_back(&mut self, mut clear_bits: u64) {
+    pub fn remove_biggest(&mut self, mut clear_bits: u64) {
         if self.len() < clear_bits {
             self.clear();
             return;
@@ -547,14 +547,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bitmap_remove_front() {
+    fn test_bitmap_remove_smallest() {
         let mut store = BitmapStore::new();
         let range = RangeInclusive::new(1, 3);
         store.insert_range(range);
         let range_second = RangeInclusive::new(5, 65535);
         // store.bits[0] = 0b1111111111111111111111111111111111111111111111111111111111101110
         store.insert_range(range_second);
-        store.remove_front(2);
+        store.remove_smallest(2);
         assert_eq!(
             store.bits[0],
             0b1111111111111111111111111111111111111111111111111111111111101000
@@ -562,14 +562,14 @@ mod tests {
     }
 
     #[test]
-    fn test_bitmap_remove_back() {
+    fn test_bitmap_remove_biggest() {
         let mut store = BitmapStore::new();
         let range = RangeInclusive::new(1, 3);
         store.insert_range(range);
         let range_second = RangeInclusive::new(5, 65535);
         // store.bits[1023] = 0b1111111111111111111111111111111111111111111111111111111111111111
         store.insert_range(range_second);
-        store.remove_back(2);
+        store.remove_biggest(2);
         assert_eq!(
             store.bits[1023],
             0b11111111111111111111111111111111111111111111111111111111111111

--- a/src/bitmap/store/mod.rs
+++ b/src/bitmap/store/mod.rs
@@ -106,17 +106,17 @@ impl Store {
         }
     }
 
-    pub fn remove_front(&mut self, index: u64) {
+    pub fn remove_smallest(&mut self, index: u64) {
         match self {
-            Array(vec) => vec.remove_front(index),
-            Bitmap(bits) => bits.remove_front(index),
+            Array(vec) => vec.remove_smallest(index),
+            Bitmap(bits) => bits.remove_smallest(index),
         }
     }
 
-    pub fn remove_back(&mut self, index: u64) {
+    pub fn remove_biggest(&mut self, index: u64) {
         match self {
-            Array(vec) => vec.remove_back(index),
-            Bitmap(bits) => bits.remove_back(index),
+            Array(vec) => vec.remove_biggest(index),
+            Bitmap(bits) => bits.remove_biggest(index),
         }
     }
 


### PR DESCRIPTION
This PR renames the `remove_front` and `remove_back` method into the clearer ones: `remove_smallest` and `remove_biggest`. These methods remove the `n` smallest or biggest values from the bitmaps.