### PR TITLE
deps: remove retain_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bytemuck = "1.7.3"
 byteorder = "1.4.3"
-retain_mut = "=0.1.7"
 serde = { version = "1.0.139", optional = true }
 
 [features]

--- a/src/bitmap/multiops.rs
+++ b/src/bitmap/multiops.rs
@@ -6,8 +6,6 @@ use std::{
     ops::{BitOrAssign, BitXorAssign},
 };
 
-use retain_mut::RetainMut;
-
 use crate::{MultiOps, RoaringBitmap};
 
 use super::{container::Container, store::Store};
@@ -229,7 +227,7 @@ fn try_multi_or_owned<E>(
         merge_container_owned(&mut containers, bitmap?.containers, BitOrAssign::bitor_assign);
     }
 
-    RetainMut::retain_mut(&mut containers, |container| {
+    containers.retain_mut(|container| {
         if container.len() > 0 {
             container.ensure_correct_store();
             true
@@ -255,7 +253,7 @@ fn try_multi_xor_owned<E>(
         merge_container_owned(&mut containers, bitmap?.containers, BitXorAssign::bitxor_assign);
     }
 
-    RetainMut::retain_mut(&mut containers, |container| {
+    containers.retain_mut(|container| {
         if container.len() > 0 {
             container.ensure_correct_store();
             true

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -1,8 +1,6 @@
 use std::mem;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
-use retain_mut::RetainMut;
-
 use crate::bitmap::container::Container;
 use crate::bitmap::Pairs;
 use crate::RoaringBitmap;
@@ -240,7 +238,7 @@ impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
             mem::swap(self, &mut rhs);
         }
 
-        RetainMut::retain_mut(&mut self.containers, |cont| {
+        self.containers.retain_mut(|cont| {
             let key = cont.key;
             match rhs.containers.binary_search_by_key(&key, |c| c.key) {
                 Ok(loc) => {
@@ -258,7 +256,7 @@ impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
 impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
     /// An `intersection` between two sets.
     fn bitand_assign(&mut self, rhs: &RoaringBitmap) {
-        RetainMut::retain_mut(&mut self.containers, |cont| {
+        self.containers.retain_mut(|cont| {
             let key = cont.key;
             match rhs.containers.binary_search_by_key(&key, |c| c.key) {
                 Ok(loc) => {
@@ -335,7 +333,7 @@ impl SubAssign<RoaringBitmap> for RoaringBitmap {
 impl SubAssign<&RoaringBitmap> for RoaringBitmap {
     /// A `difference` between two sets.
     fn sub_assign(&mut self, rhs: &RoaringBitmap) {
-        RetainMut::retain_mut(&mut self.containers, |cont| {
+        self.containers.retain_mut(|cont| {
             match rhs.containers.binary_search_by_key(&cont.key, |c| c.key) {
                 Ok(loc) => {
                     SubAssign::sub_assign(cont, &rhs.containers[loc]);


### PR DESCRIPTION
Per the crate's README:

    This crate has been deprecated. Rust 1.61 stabilized retain_mut for
    Vec and VecDeque, so you can use them directly. This crate is no
    longer maintained.

MSRV has been bumped to 1.65 in 42ae34266e27b, we no longer need this crate.