### PR TITLE
docs: `RoaringTreemap::select` returns `None` if `n >= len()`

### DIFF
--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -385,7 +385,7 @@ impl RoaringTreemap {
             + iter.map(|(_, bitmap)| bitmap.len()).sum::<u64>()
     }
 
-    /// Returns the `n`th integer in the set or `None` if `n <= len()`
+    /// Returns the `n`th integer in the set or `None` if `n >= len()`
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Same as `RoaringBitmap::select`: https://docs.rs/roaring/latest/roaring/bitmap/struct.RoaringBitmap.html#method.select