### PR TITLE
feat: support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bytemuck = "1.7.3"
-byteorder = "1.4.3"
+byteorder = { version = "1.4.3", default-features = false }
 serde = { version = "1.0.139", optional = true }
 
 [features]
+default = ["std"]
 simd = []
+std = ["byteorder/std"]
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ https://github.com/RoaringBitmap/roaring-rs/actions/workflows/test.yml/badge.svg
 ## Experimental features
 
 The `simd` feature is in active development. It has not been tested. If you would like to build with `simd` note that
-`core::simd` is only available in Rust nightly.
+`std::simd` is only available in Rust nightly.

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ https://github.com/RoaringBitmap/roaring-rs/actions/workflows/test.yml/badge.svg
 ## Experimental features
 
 The `simd` feature is in active development. It has not been tested. If you would like to build with `simd` note that
-`std::simd` is only available in Rust nightly.
+`core::simd` is only available in Rust nightly.

--- a/benchmarks/benches/datasets.rs
+++ b/benchmarks/benches/datasets.rs
@@ -1,7 +1,7 @@
-use std::env;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
+use core::env;
+use core::fs::File;
+use core::io::BufReader;
+use core::path::{Path, PathBuf};
 
 use git2::FetchOptions;
 use once_cell::sync::OnceCell as SyncOnceCell;
@@ -13,7 +13,7 @@ static INSTANCE: SyncOnceCell<Vec<Dataset>> = SyncOnceCell::new();
 pub struct Datasets;
 
 pub struct DatasetsIter {
-    iter: std::slice::Iter<'static, Dataset>,
+    iter: core::slice::Iter<'static, Dataset>,
 }
 
 impl Iterator for DatasetsIter {
@@ -44,7 +44,7 @@ pub struct Dataset {
     pub bitmaps: Vec<RoaringBitmap>,
 }
 
-fn init_datasets() -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn init_datasets() -> Result<PathBuf, Box<dyn core::error::Error>> {
     let out_dir = env::var_os("CARGO_MANIFEST_DIR").ok_or(env::VarError::NotPresent)?;
 
     let out_path = Path::new(&out_dir);
@@ -122,7 +122,7 @@ fn init_datasets() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Ok(repo_path)
 }
 
-fn parse_datasets<P: AsRef<Path>>(path: P) -> Result<Vec<Dataset>, Box<dyn std::error::Error>> {
+fn parse_datasets<P: AsRef<Path>>(path: P) -> Result<Vec<Dataset>, Box<dyn core::error::Error>> {
     const DATASET_FILENAME_WHITELIST: &[&str] = &[
         "census-income.zip",
         "census-income_srt.zip",
@@ -135,7 +135,7 @@ fn parse_datasets<P: AsRef<Path>>(path: P) -> Result<Vec<Dataset>, Box<dyn std::
     ];
 
     use indicatif::{ProgressBar, ProgressStyle};
-    use std::io::BufRead;
+    use core::io::BufRead;
     use zip::ZipArchive;
 
     let dir = path.as_ref().read_dir()?;

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
-use std::cmp::Reverse;
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
+use core::cmp::Reverse;
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use criterion::measurement::Measurement;
 use criterion::{

--- a/src/bitmap/arbitrary.rs
+++ b/src/bitmap/arbitrary.rs
@@ -5,10 +5,10 @@ mod test {
     use crate::RoaringBitmap;
     use alloc::boxed::Box;
     use alloc::vec::Vec;
+    use core::fmt::{Debug, Formatter};
     use proptest::bits::{BitSetLike, BitSetStrategy, SampledBitSetStrategy};
     use proptest::collection::{vec, SizeRange};
     use proptest::prelude::*;
-    use core::fmt::{Debug, Formatter};
 
     impl Debug for BitmapStore {
         fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/src/bitmap/arbitrary.rs
+++ b/src/bitmap/arbitrary.rs
@@ -3,13 +3,15 @@ mod test {
     use crate::bitmap::container::Container;
     use crate::bitmap::store::{ArrayStore, BitmapStore, Store};
     use crate::RoaringBitmap;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
     use proptest::bits::{BitSetLike, BitSetStrategy, SampledBitSetStrategy};
     use proptest::collection::{vec, SizeRange};
     use proptest::prelude::*;
-    use std::fmt::{Debug, Formatter};
+    use core::fmt::{Debug, Formatter};
 
     impl Debug for BitmapStore {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
             if self.len() < 16 {
                 write!(f, "BitmapStore<{:?}>", self.iter().collect::<Vec<u16>>())
             } else {
@@ -82,7 +84,7 @@ mod test {
     }
 
     impl Debug for ArrayStore {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
             if self.len() < 16 {
                 write!(f, "ArrayStore<{:?}>", self.as_slice())
             } else {
@@ -151,7 +153,7 @@ mod test {
     }
 
     impl Debug for Store {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
             match self {
                 Store::Array(a) => write!(f, "Store({:?})", a),
                 Store::Bitmap(b) => write!(f, "Store({:?})", b),

--- a/src/bitmap/cmp.rs
+++ b/src/bitmap/cmp.rs
@@ -1,6 +1,6 @@
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::iter::Peekable;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::iter::Peekable;
 
 use super::container::Container;
 use crate::RoaringBitmap;

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,7 +1,9 @@
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,
 };
+
+use alloc::vec::Vec;
 
 use super::store::{self, Store};
 use super::util;

--- a/src/bitmap/fmt.rs
+++ b/src/bitmap/fmt.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use core::fmt;
+
+use alloc::vec::Vec;
 
 use crate::RoaringBitmap;
 

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -1,5 +1,7 @@
-use std::cmp::Ordering;
-use std::ops::RangeBounds;
+use core::cmp::Ordering;
+use core::ops::RangeBounds;
+
+use alloc::vec::Vec;
 
 use crate::RoaringBitmap;
 

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -1,6 +1,6 @@
+use alloc::vec::{self, Vec};
 use core::iter::{self, FromIterator};
 use core::slice;
-use alloc::vec::{self, Vec};
 
 use super::container::Container;
 use crate::{NonSortedIntegers, RoaringBitmap};

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -1,5 +1,6 @@
-use std::iter::{self, FromIterator};
-use std::{slice, vec};
+use core::iter::{self, FromIterator};
+use core::slice;
+use alloc::vec::{self, Vec};
 
 use super::container::Container;
 use crate::{NonSortedIntegers, RoaringBitmap};
@@ -99,7 +100,7 @@ impl RoaringBitmap {
     ///
     /// ```rust
     /// use roaring::RoaringBitmap;
-    /// use std::iter::FromIterator;
+    /// use core::iter::FromIterator;
     ///
     /// let bitmap = (1..3).collect::<RoaringBitmap>();
     /// let mut iter = bitmap.iter();

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -14,7 +14,10 @@ mod iter;
 mod ops;
 #[cfg(feature = "serde")]
 mod serde;
+#[cfg(feature = "std")]
 mod serialization;
+
+use alloc::vec::Vec;
 
 use self::cmp::Pairs;
 pub use self::iter::IntoIter;

--- a/src/bitmap/multiops.rs
+++ b/src/bitmap/multiops.rs
@@ -5,7 +5,7 @@ use core::{
     ops::{BitOrAssign, BitXorAssign},
 };
 
-use alloc::{vec::Vec, borrow::Cow};
+use alloc::{borrow::Cow, vec::Vec};
 
 use crate::{MultiOps, RoaringBitmap};
 

--- a/src/bitmap/multiops.rs
+++ b/src/bitmap/multiops.rs
@@ -1,10 +1,11 @@
-use std::{
-    borrow::Cow,
+use core::{
     cmp::Reverse,
     convert::Infallible,
     mem,
     ops::{BitOrAssign, BitXorAssign},
 };
+
+use alloc::{vec::Vec, borrow::Cow};
 
 use crate::{MultiOps, RoaringBitmap};
 

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -442,8 +442,8 @@ impl BitXorAssign<&RoaringBitmap> for RoaringBitmap {
 #[cfg(test)]
 mod test {
     use crate::{MultiOps, RoaringBitmap};
-    use proptest::prelude::*;
     use core::convert::Infallible;
+    use proptest::prelude::*;
 
     // fast count tests
     proptest! {

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -1,5 +1,7 @@
-use std::mem;
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
+use core::mem;
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
+
+use alloc::vec::Vec;
 
 use crate::bitmap::container::Container;
 use crate::bitmap::Pairs;
@@ -441,7 +443,7 @@ impl BitXorAssign<&RoaringBitmap> for RoaringBitmap {
 mod test {
     use crate::{MultiOps, RoaringBitmap};
     use proptest::prelude::*;
-    use std::convert::Infallible;
+    use core::convert::Infallible;
 
     // fast count tests
     proptest! {

--- a/src/bitmap/serde.rs
+++ b/src/bitmap/serde.rs
@@ -16,7 +16,7 @@ impl<'de> Deserialize<'de> for RoaringBitmap {
         impl<'de> Visitor<'de> for BitmapVisitor {
             type Value = RoaringBitmap;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 formatter.write_str("roaring bitmap")
             }
 

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -1,9 +1,9 @@
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::convert::{Infallible, TryFrom};
+use core::convert::{Infallible, TryFrom};
 use std::error::Error;
 use std::io;
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 use crate::bitmap::container::{Container, ARRAY_LIMIT};
 use crate::bitmap::store::{ArrayStore, BitmapStore, Store, BITMAP_LENGTH};

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -1,9 +1,9 @@
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use core::convert::{Infallible, TryFrom};
+use core::ops::RangeInclusive;
 use std::error::Error;
 use std::io;
-use core::ops::RangeInclusive;
 
 use crate::bitmap::container::{Container, ARRAY_LIMIT};
 use crate::bitmap::store::{ArrayStore, BitmapStore, Store, BITMAP_LENGTH};

--- a/src/bitmap/store/array_store/mod.rs
+++ b/src/bitmap/store/array_store/mod.rs
@@ -2,12 +2,15 @@ mod scalar;
 mod vector;
 mod visitor;
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use crate::bitmap::store::array_store::visitor::{CardinalityCounter, VecWriter};
-use std::cmp::Ordering;
-use std::cmp::Ordering::*;
-use std::convert::{TryFrom, TryInto};
-use std::fmt::{Display, Formatter};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitXor, RangeInclusive, Sub, SubAssign};
+use core::cmp::Ordering;
+use core::cmp::Ordering::*;
+use core::convert::TryFrom;
+use core::fmt::{Display, Formatter};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitXor, RangeInclusive, Sub, SubAssign};
 
 use super::bitmap_store::{bit, key, BitmapStore, BITMAP_LENGTH};
 
@@ -214,11 +217,11 @@ impl ArrayStore {
         self.vec.get(n as usize).cloned()
     }
 
-    pub fn iter(&self) -> std::slice::Iter<u16> {
+    pub fn iter(&self) -> core::slice::Iter<u16> {
         self.vec.iter()
     }
 
-    pub fn into_iter(self) -> std::vec::IntoIter<u16> {
+    pub fn into_iter(self) -> alloc::vec::IntoIter<u16> {
         self.vec.into_iter()
     }
 
@@ -263,7 +266,7 @@ pub enum ErrorKind {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self.kind {
             ErrorKind::Duplicate => {
                 write!(f, "Duplicate element found at index: {}", self.index)
@@ -275,6 +278,7 @@ impl Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 impl TryFrom<Vec<u16>> for ArrayStore {

--- a/src/bitmap/store/array_store/scalar.rs
+++ b/src/bitmap/store/array_store/scalar.rs
@@ -1,7 +1,7 @@
 //! Scalar arithmetic binary set operations on `ArrayStore`'s inner types
 
 use crate::bitmap::store::array_store::visitor::BinaryOperationVisitor;
-use std::cmp::Ordering::*;
+use core::cmp::Ordering::*;
 
 #[inline]
 pub fn or(lhs: &[u16], rhs: &[u16], visitor: &mut impl BinaryOperationVisitor) {

--- a/src/bitmap/store/array_store/vector.rs
+++ b/src/bitmap/store/array_store/vector.rs
@@ -390,7 +390,7 @@ where
     U: SimdElement + PartialOrd,
     LaneCount<LANES>: SupportedLaneCount,
 {
-    unsafe { std::ptr::read_unaligned(src as *const _ as *const Simd<U, LANES>) }
+    unsafe { core::ptr::read_unaligned(src as *const _ as *const Simd<U, LANES>) }
 }
 
 /// write `v` to slice `out`
@@ -416,7 +416,7 @@ where
     U: SimdElement + PartialOrd,
     LaneCount<LANES>: SupportedLaneCount,
 {
-    unsafe { std::ptr::write_unaligned(out as *mut _ as *mut Simd<U, LANES>, v) }
+    unsafe { core::ptr::write_unaligned(out as *mut _ as *mut Simd<U, LANES>, v) }
 }
 
 /// Compare all lanes in `a` to all lanes in `b`

--- a/src/bitmap/store/array_store/visitor.rs
+++ b/src/bitmap/store/array_store/visitor.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 #[cfg(feature = "simd")]
 use crate::bitmap::store::array_store::vector::swizzle_to_front;
 

--- a/src/bitmap/store/bitmap_store.rs
+++ b/src/bitmap/store/bitmap_store.rs
@@ -1,7 +1,10 @@
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::fmt::{Display, Formatter};
-use std::ops::{BitAndAssign, BitOrAssign, BitXorAssign, RangeInclusive, SubAssign};
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::fmt::{Display, Formatter};
+use core::ops::{BitAndAssign, BitOrAssign, BitXorAssign, RangeInclusive, SubAssign};
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use super::ArrayStore;
 
@@ -382,7 +385,7 @@ pub enum ErrorKind {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self.kind {
             ErrorKind::Cardinality { expected, actual } => {
                 write!(f, "Expected cardinality was {} but was {}", expected, actual)
@@ -391,6 +394,7 @@ impl Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 pub struct BitmapIter<B: Borrow<[u64; BITMAP_LENGTH]>> {

--- a/src/bitmap/store/mod.rs
+++ b/src/bitmap/store/mod.rs
@@ -1,12 +1,12 @@
 mod array_store;
 mod bitmap_store;
 
+use alloc::{boxed::Box, vec};
 use core::mem;
 use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,
 };
 use core::slice;
-use alloc::{vec, boxed::Box};
 
 pub use self::bitmap_store::BITMAP_LENGTH;
 use self::Store::{Array, Bitmap};

--- a/src/bitmap/store/mod.rs
+++ b/src/bitmap/store/mod.rs
@@ -1,11 +1,12 @@
 mod array_store;
 mod bitmap_store;
 
-use std::mem;
-use std::ops::{
+use core::mem;
+use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,
 };
-use std::{slice, vec};
+use core::slice;
+use alloc::{vec, boxed::Box};
 
 pub use self::bitmap_store::BITMAP_LENGTH;
 use self::Store::{Array, Bitmap};

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, RangeBounds, RangeInclusive};
+use core::ops::{Bound, RangeBounds, RangeInclusive};
 
 /// Returns the container key and the index
 /// in this container for a given integer.
@@ -38,7 +38,7 @@ where
 #[cfg(test)]
 mod test {
     use super::{convert_range_to_inclusive, join, split};
-    use std::ops::Bound;
+    use core::ops::Bound;
 
     #[test]
     fn test_split_u32() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! [roaring-java]: https://github.com/lemire/RoaringBitmap
 //! [roaring-paper]: https://arxiv.org/pdf/1402.6407v4
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 #![warn(missing_docs)]
 #![warn(unsafe_op_in_unsafe_fn)]
@@ -15,8 +16,10 @@
 
 extern crate byteorder;
 
-use std::error::Error;
-use std::fmt;
+#[macro_use]
+extern crate alloc;
+
+use core::fmt;
 
 /// A compressed bitmap using the [Roaring bitmap compression scheme](https://roaringbitmap.org/).
 pub mod bitmap;
@@ -46,7 +49,8 @@ impl fmt::Display for NonSortedIntegers {
     }
 }
 
-impl Error for NonSortedIntegers {}
+#[cfg(feature = "std")]
+impl std::error::Error for NonSortedIntegers {}
 
 /// A [`Iterator::collect`] blanket implementation that provides extra methods for [`RoaringBitmap`]
 /// and [`RoaringTreemap`].

--- a/src/treemap/cmp.rs
+++ b/src/treemap/cmp.rs
@@ -1,5 +1,5 @@
-use std::collections::btree_map;
-use std::iter::Peekable;
+use alloc::collections::btree_map;
+use core::iter::Peekable;
 
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;

--- a/src/treemap/fmt.rs
+++ b/src/treemap/fmt.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use core::fmt;
+
+use alloc::vec::Vec;
 
 use crate::RoaringTreemap;
 

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -1,6 +1,7 @@
-use std::collections::btree_map::{BTreeMap, Entry};
-use std::iter;
-use std::ops::RangeBounds;
+use alloc::collections::btree_map::{BTreeMap, Entry};
+use alloc::vec::Vec;
+use core::iter;
+use core::ops::RangeBounds;
 
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -1,6 +1,5 @@
-use std::collections::btree_map;
-use std::collections::BTreeMap;
-use std::iter::{self, FromIterator};
+use alloc::collections::{btree_map, BTreeMap};
+use core::iter::{self, FromIterator};
 
 use super::util;
 use crate::bitmap::IntoIter as IntoIter32;
@@ -160,7 +159,7 @@ impl RoaringTreemap {
     ///
     /// ```rust
     /// use roaring::RoaringTreemap;
-    /// use std::iter::FromIterator;
+    /// use core::iter::FromIterator;
     ///
     /// let bitmap = (1..3).collect::<RoaringTreemap>();
     /// let mut iter = bitmap.iter();
@@ -180,7 +179,7 @@ impl RoaringTreemap {
     ///
     /// ```rust
     /// use roaring::{RoaringBitmap, RoaringTreemap};
-    /// use std::iter::FromIterator;
+    /// use core::iter::FromIterator;
     ///
     /// let original = (0..6000).collect::<RoaringTreemap>();
     /// let mut bitmaps = original.bitmaps();
@@ -200,7 +199,7 @@ impl RoaringTreemap {
     ///
     /// ```rust
     /// use roaring::RoaringTreemap;
-    /// use std::iter::FromIterator;
+    /// use core::iter::FromIterator;
     ///
     /// let original = (0..6000).collect::<RoaringTreemap>();
     /// let clone = RoaringTreemap::from_bitmaps(original.bitmaps().map(|(p, b)| (p, b.clone())));

--- a/src/treemap/mod.rs
+++ b/src/treemap/mod.rs
@@ -1,5 +1,5 @@
 use crate::RoaringBitmap;
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 mod fmt;
 mod multiops;
@@ -14,6 +14,7 @@ mod iter;
 mod ops;
 #[cfg(feature = "serde")]
 mod serde;
+#[cfg(feature = "std")]
 mod serialization;
 
 pub use self::iter::{IntoIter, Iter};

--- a/src/treemap/multiops.rs
+++ b/src/treemap/multiops.rs
@@ -1,9 +1,9 @@
-use std::{
+use core::{
     borrow::Borrow,
     cmp::Ordering,
-    collections::{binary_heap::PeekMut, BTreeMap, BinaryHeap},
     mem,
 };
+use alloc::{collections::{binary_heap::PeekMut, BTreeMap, BinaryHeap}, vec::Vec};
 
 use crate::{MultiOps, RoaringBitmap, RoaringTreemap};
 
@@ -15,28 +15,28 @@ where
 
     fn union(self) -> Self::Output {
         try_simple_multi_op_owned::<_, _, UnionOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
 
     fn intersection(self) -> Self::Output {
         try_ordered_multi_op_owned::<_, _, IntersectionOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
 
     fn difference(self) -> Self::Output {
         try_ordered_multi_op_owned::<_, _, DifferenceOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
 
     fn symmetric_difference(self) -> Self::Output {
         try_simple_multi_op_owned::<_, _, SymmetricDifferenceOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
@@ -140,7 +140,7 @@ where
         // the unwrap is safe since we're iterating on our keys
         let current_bitmap = treemap.map.remove(&k).unwrap();
         let new_bitmap =
-            O::op_owned(std::iter::once(current_bitmap).chain(
+            O::op_owned(core::iter::once(current_bitmap).chain(
                 treemaps.iter_mut().map(|treemap| treemap.map.remove(&k).unwrap_or_default()),
             ));
         if !new_bitmap.is_empty() {
@@ -172,7 +172,7 @@ where
         // the unwrap is safe since we're iterating on our keys
         let current_bitmap = treemap.map.get(&k).unwrap();
         let new_bitmap = O::op_ref(
-            std::iter::once(current_bitmap)
+            core::iter::once(current_bitmap)
                 .chain(treemaps.iter().map(|treemap| treemap.map.get(&k).unwrap_or(&empty_bitmap))),
         );
         if !new_bitmap.is_empty() {
@@ -300,28 +300,28 @@ where
 
     fn union(self) -> Self::Output {
         try_simple_multi_op_ref::<_, _, UnionOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
 
     fn intersection(self) -> Self::Output {
         try_ordered_multi_op_ref::<_, _, IntersectionOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
 
     fn difference(self) -> Self::Output {
         try_ordered_multi_op_ref::<_, _, DifferenceOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }
 
     fn symmetric_difference(self) -> Self::Output {
         try_simple_multi_op_ref::<_, _, SymmetricDifferenceOp>(
-            self.into_iter().map(Ok::<_, std::convert::Infallible>),
+            self.into_iter().map(Ok::<_, core::convert::Infallible>),
         )
         .unwrap()
     }

--- a/src/treemap/multiops.rs
+++ b/src/treemap/multiops.rs
@@ -1,9 +1,8 @@
-use core::{
-    borrow::Borrow,
-    cmp::Ordering,
-    mem,
+use alloc::{
+    collections::{binary_heap::PeekMut, BTreeMap, BinaryHeap},
+    vec::Vec,
 };
-use alloc::{collections::{binary_heap::PeekMut, BTreeMap, BinaryHeap}, vec::Vec};
+use core::{borrow::Borrow, cmp::Ordering, mem};
 
 use crate::{MultiOps, RoaringBitmap, RoaringTreemap};
 

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -1,6 +1,7 @@
-use std::collections::btree_map::Entry;
-use std::mem;
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
+use alloc::collections::btree_map::Entry;
+use alloc::vec::Vec;
+use core::mem;
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use crate::RoaringTreemap;
 

--- a/src/treemap/serde.rs
+++ b/src/treemap/serde.rs
@@ -16,7 +16,7 @@ impl<'de> Deserialize<'de> for RoaringTreemap {
         impl<'de> Visitor<'de> for TreemapVisitor {
             type Value = RoaringTreemap;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 formatter.write_str("roaring bitmap")
             }
 

--- a/src/treemap/util.rs
+++ b/src/treemap/util.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, RangeBounds, RangeInclusive};
+use core::ops::{Bound, RangeBounds, RangeInclusive};
 
 #[inline]
 pub fn split(value: u64) -> (u32, u32) {

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,7 +1,7 @@
 use proptest::arbitrary::any;
 use proptest::collection::btree_set;
 use proptest::proptest;
-use std::iter::FromIterator;
+use core::iter::FromIterator;
 
 use roaring::RoaringBitmap;
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,7 +1,7 @@
+use core::iter::FromIterator;
 use proptest::arbitrary::any;
 use proptest::collection::btree_set;
 use proptest::proptest;
-use core::iter::FromIterator;
 
 use roaring::RoaringBitmap;
 

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,6 +1,6 @@
 extern crate roaring;
 use roaring::{RoaringBitmap, RoaringTreemap};
-use std::iter::FromIterator;
+use core::iter::FromIterator;
 
 /// macro created to reduce code duplication
 macro_rules! test_from_sorted_iter {

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,6 +1,6 @@
 extern crate roaring;
-use roaring::{RoaringBitmap, RoaringTreemap};
 use core::iter::FromIterator;
+use roaring::{RoaringBitmap, RoaringTreemap};
 
 /// macro created to reduce code duplication
 macro_rules! test_from_sorted_iter {

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -85,8 +85,8 @@ fn test_array_boundary() {
 #[test]
 #[cfg(feature = "std")]
 fn test_bitmap_boundary() {
-#[cfg(feature = "std")]
-let original = (1000..5097).collect::<RoaringBitmap>();
+    #[cfg(feature = "std")]
+    let original = (1000..5097).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -1,11 +1,15 @@
 extern crate roaring;
 
+#[cfg(feature = "std")]
 use roaring::RoaringBitmap;
 
 // Test data from https://github.com/RoaringBitmap/RoaringFormatSpec/tree/master/testdata
+#[cfg(feature = "std")]
 static BITMAP_WITHOUT_RUNS: &[u8] = include_bytes!("bitmapwithoutruns.bin");
+#[cfg(feature = "std")]
 static BITMAP_WITH_RUNS: &[u8] = include_bytes!("bitmapwithruns.bin");
 
+#[cfg(feature = "std")]
 fn test_data_bitmap() -> RoaringBitmap {
     (0..100)
         .map(|i| i * 1000)
@@ -14,6 +18,7 @@ fn test_data_bitmap() -> RoaringBitmap {
         .collect::<RoaringBitmap>()
 }
 
+#[cfg(feature = "std")]
 fn serialize_and_deserialize(bitmap: &RoaringBitmap) -> RoaringBitmap {
     let mut buffer = vec![];
     bitmap.serialize_into(&mut buffer).unwrap();
@@ -22,11 +27,13 @@ fn serialize_and_deserialize(bitmap: &RoaringBitmap) -> RoaringBitmap {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_deserialize_without_runs_from_provided_data() {
     assert_eq!(RoaringBitmap::deserialize_from(BITMAP_WITHOUT_RUNS).unwrap(), test_data_bitmap());
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_deserialize_with_runs_from_provided_data() {
     assert_eq!(
         RoaringBitmap::deserialize_from(&mut &BITMAP_WITH_RUNS[..]).unwrap(),
@@ -35,6 +42,7 @@ fn test_deserialize_with_runs_from_provided_data() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_serialize_into_provided_data() {
     let bitmap = test_data_bitmap();
     let mut buffer = vec![];
@@ -43,6 +51,7 @@ fn test_serialize_into_provided_data() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_empty() {
     let original = RoaringBitmap::new();
     let new = serialize_and_deserialize(&original);
@@ -50,6 +59,7 @@ fn test_empty() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_one() {
     let original = (1..2).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -57,6 +67,7 @@ fn test_one() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_array() {
     let original = (1000..3000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -64,6 +75,7 @@ fn test_array() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_array_boundary() {
     let original = (1000..5096).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -71,13 +83,16 @@ fn test_array_boundary() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_bitmap_boundary() {
-    let original = (1000..5097).collect::<RoaringBitmap>();
+#[cfg(feature = "std")]
+let original = (1000..5097).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
     assert_eq!(original, new);
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_bitmap_high16bits() {
     let mut bitmap = RoaringBitmap::new();
     for i in 0..1 << 16 {
@@ -94,6 +109,7 @@ fn test_bitmap_high16bits() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_bitmap() {
     let original = (1000..6000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -101,6 +117,7 @@ fn test_bitmap() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_arrays() {
     let original = (1000..3000).chain(70000..74000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -108,6 +125,7 @@ fn test_arrays() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_bitmaps() {
     let original = (1000..6000).chain(70000..77000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -115,6 +133,7 @@ fn test_bitmaps() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_mixed() {
     let original = (1000..3000).chain(70000..77000).collect::<RoaringBitmap>();
     let new = serialize_and_deserialize(&original);
@@ -122,6 +141,7 @@ fn test_mixed() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_strange() {
     const ARRAY: &[u32] = &[
         6619162, 6619180, 6619181, 6619217, 6619218, 6619257, 6619258, 6619259, 6619260, 6619261,

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -2,11 +2,11 @@ extern crate roaring;
 mod iter;
 use roaring::RoaringTreemap;
 
+use core::iter::FromIterator;
 use iter::outside_in;
 use proptest::arbitrary::any;
 use proptest::collection::btree_set;
 use proptest::proptest;
-use core::iter::FromIterator;
 
 #[test]
 fn range() {

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -6,7 +6,7 @@ use iter::outside_in;
 use proptest::arbitrary::any;
 use proptest::collection::btree_set;
 use proptest::proptest;
-use std::iter::FromIterator;
+use core::iter::FromIterator;
 
 #[test]
 fn range() {

--- a/tests/treemap_rank.rs
+++ b/tests/treemap_rank.rs
@@ -3,7 +3,7 @@ extern crate roaring;
 use proptest::collection::{btree_set, vec};
 use proptest::prelude::*;
 use roaring::RoaringTreemap;
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 const BITMAP_MAX: u64 = u32::MAX as u64;
 

--- a/tests/treemap_rank.rs
+++ b/tests/treemap_rank.rs
@@ -1,9 +1,9 @@
 extern crate roaring;
 
+use core::ops::RangeInclusive;
 use proptest::collection::{btree_set, vec};
 use proptest::prelude::*;
 use roaring::RoaringTreemap;
-use core::ops::RangeInclusive;
 
 const BITMAP_MAX: u64 = u32::MAX as u64;
 

--- a/tests/treemap_serialization.rs
+++ b/tests/treemap_serialization.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "std")]
 use roaring::RoaringTreemap;
-use std::iter::FromIterator;
+#[cfg(feature = "std")]
+use core::iter::FromIterator;
 
+#[cfg(feature = "std")]
 fn serialize_deserialize<Dataset, I>(dataset: Dataset)
 where
     Dataset: IntoIterator<Item = u64, IntoIter = I>,
@@ -19,21 +22,25 @@ where
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn empty() {
     serialize_deserialize(vec![])
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn basic() {
     serialize_deserialize(vec![1, 2, 3, 4, 5, 100, 1000])
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn basic_2() {
     serialize_deserialize(vec![1, 2, 3, 4, 5, 100, 1000, 10000, 100000, 1000000])
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn basic_3() {
     let u32max = u32::MAX as u64;
     serialize_deserialize(

--- a/tests/treemap_serialization.rs
+++ b/tests/treemap_serialization.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "std")]
-use roaring::RoaringTreemap;
-#[cfg(feature = "std")]
 use core::iter::FromIterator;
+#[cfg(feature = "std")]
+use roaring::RoaringTreemap;
 
 #[cfg(feature = "std")]
 fn serialize_deserialize<Dataset, I>(dataset: Dataset)


### PR DESCRIPTION
This is only a early pr for support `no_std`.

All tests are passed. Use `core` and `alloc` instead of `std`.

There should be some better ways to disable serialization tests when `no_std`.

For issue #265