### PR TITLE
Bump roaring to v0.10.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roaring"
-version = "0.10.3"
+version = "0.10.4"
 rust-version = "1.65.0"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "A better compressed bitset - pure Rust implementation"


### PR DESCRIPTION
This PR bumps the version to v0.10.4.