### PR TITLE
Direct intersections with serialized RoaringBitmaps

### DIFF
--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -37,6 +37,10 @@ impl Container {
         self.store.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.store.is_empty()
+    }
+
     pub fn insert(&mut self, index: u16) -> bool {
         if self.store.insert(index) {
             self.ensure_correct_store();

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -208,7 +208,7 @@ impl RoaringBitmap {
         match self.containers.binary_search_by_key(&key, |c| c.key) {
             Ok(loc) => {
                 if self.containers[loc].remove(index) {
-                    if self.containers[loc].len() == 0 {
+                    if self.containers[loc].is_empty() {
                         self.containers.remove(loc);
                     }
                     true
@@ -253,7 +253,7 @@ impl RoaringBitmap {
                 let a = if key == start_container_key { start_index } else { 0 };
                 let b = if key == end_container_key { end_index } else { u16::MAX };
                 removed += self.containers[index].remove_range(a..=b);
-                if self.containers[index].len() == 0 {
+                if self.containers[index].is_empty() {
                     self.containers.remove(index);
                     continue;
                 }

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -12,10 +12,11 @@ mod cmp;
 mod inherent;
 mod iter;
 mod ops;
+mod ops_with_serialized;
 #[cfg(feature = "serde")]
 mod serde;
 #[cfg(feature = "std")]
-mod serialization;
+pub(crate) mod serialization;
 
 use self::cmp::Pairs;
 pub use self::iter::IntoIter;

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -12,6 +12,7 @@ mod cmp;
 mod inherent;
 mod iter;
 mod ops;
+#[cfg(feature = "std")]
 mod ops_with_serialized;
 #[cfg(feature = "serde")]
 mod serde;

--- a/src/bitmap/multiops.rs
+++ b/src/bitmap/multiops.rs
@@ -232,7 +232,7 @@ fn try_multi_or_owned<E>(
     }
 
     containers.retain_mut(|container| {
-        if container.len() > 0 {
+        if !container.is_empty() {
             container.ensure_correct_store();
             true
         } else {
@@ -258,7 +258,7 @@ fn try_multi_xor_owned<E>(
     }
 
     containers.retain_mut(|container| {
-        if container.len() > 0 {
+        if !container.is_empty() {
             container.ensure_correct_store();
             true
         } else {

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -223,7 +223,7 @@ impl BitAnd<&RoaringBitmap> for &RoaringBitmap {
         for pair in Pairs::new(&self.containers, &rhs.containers) {
             if let (Some(lhs), Some(rhs)) = pair {
                 let container = BitAnd::bitand(lhs, rhs);
-                if container.len() != 0 {
+                if !container.is_empty() {
                     containers.push(container);
                 }
             }
@@ -248,7 +248,7 @@ impl BitAndAssign<RoaringBitmap> for RoaringBitmap {
                     let rhs_cont = &mut rhs.containers[loc];
                     let rhs_cont = mem::replace(rhs_cont, Container::new(rhs_cont.key));
                     BitAndAssign::bitand_assign(cont, rhs_cont);
-                    cont.len() != 0
+                    !cont.is_empty()
                 }
                 Err(_) => false,
             }
@@ -264,7 +264,7 @@ impl BitAndAssign<&RoaringBitmap> for RoaringBitmap {
             match rhs.containers.binary_search_by_key(&key, |c| c.key) {
                 Ok(loc) => {
                     BitAndAssign::bitand_assign(cont, &rhs.containers[loc]);
-                    cont.len() != 0
+                    !cont.is_empty()
                 }
                 Err(_) => false,
             }
@@ -314,7 +314,7 @@ impl Sub<&RoaringBitmap> for &RoaringBitmap {
                 (None, Some(_)) => (),
                 (Some(lhs), Some(rhs)) => {
                     let container = Sub::sub(lhs, rhs);
-                    if container.len() != 0 {
+                    if !container.is_empty() {
                         containers.push(container);
                     }
                 }
@@ -340,7 +340,7 @@ impl SubAssign<&RoaringBitmap> for RoaringBitmap {
             match rhs.containers.binary_search_by_key(&cont.key, |c| c.key) {
                 Ok(loc) => {
                     SubAssign::sub_assign(cont, &rhs.containers[loc]);
-                    cont.len() != 0
+                    !cont.is_empty()
                 }
                 Err(_) => true,
             }
@@ -390,7 +390,7 @@ impl BitXor<&RoaringBitmap> for &RoaringBitmap {
                 (None, Some(rhs)) => containers.push(rhs.clone()),
                 (Some(lhs), Some(rhs)) => {
                     let container = BitXor::bitxor(lhs, rhs);
-                    if container.len() != 0 {
+                    if !container.is_empty() {
                         containers.push(container);
                     }
                 }
@@ -409,7 +409,7 @@ impl BitXorAssign<RoaringBitmap> for RoaringBitmap {
             match pair {
                 (Some(mut lhs), Some(rhs)) => {
                     BitXorAssign::bitxor_assign(&mut lhs, rhs);
-                    if lhs.len() != 0 {
+                    if !lhs.is_empty() {
                         self.containers.push(lhs);
                     }
                 }
@@ -428,7 +428,7 @@ impl BitXorAssign<&RoaringBitmap> for RoaringBitmap {
             match pair {
                 (Some(mut lhs), Some(rhs)) => {
                     BitXorAssign::bitxor_assign(&mut lhs, rhs);
-                    if lhs.len() != 0 {
+                    if !lhs.is_empty() {
                         self.containers.push(lhs);
                     }
                 }

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -104,19 +104,14 @@ impl RoaringBitmap {
             let mut offsets = vec![0; size];
             reader.read_exact(cast_slice_mut(&mut offsets))?;
             offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
-
-            // Loop on the materialized containers if there
-            // are less or as many of them than serialized ones.
-            if self.containers.len() <= size {
-                return self.intersection_with_serialized_impl_with_offsets(
-                    reader,
-                    a,
-                    b,
-                    &descriptions,
-                    &offsets,
-                    run_container_bitmap.as_deref(),
-                );
-            }
+            return self.intersection_with_serialized_impl_with_offsets(
+                reader,
+                a,
+                b,
+                &descriptions,
+                &offsets,
+                run_container_bitmap.as_deref(),
+            );
         }
 
         // Read each container and skip the useless ones

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -1,0 +1,145 @@
+use bytemuck::{cast_slice_mut, pod_collect_to_vec};
+use byteorder::{LittleEndian, ReadBytesExt};
+use core::convert::Infallible;
+use core::ops::{BitAndAssign, RangeInclusive};
+use std::error::Error;
+use std::io;
+
+use crate::bitmap::container::Container;
+use crate::bitmap::serialization::{
+    DESCRIPTION_BYTES, NO_OFFSET_THRESHOLD, OFFSET_BYTES, SERIAL_COOKIE,
+    SERIAL_COOKIE_NO_RUNCONTAINER,
+};
+use crate::RoaringBitmap;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::container::ARRAY_LIMIT;
+use super::store::{ArrayStore, BitmapStore, Store, BITMAP_LENGTH};
+
+impl RoaringBitmap {
+    /// Computes the len of the intersection with the specified other bitmap without creating a
+    /// new bitmap.
+    ///
+    /// This is faster and more space efficient when you're only interested in the cardinality of
+    /// the intersection.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    ///
+    /// let rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    ///
+    /// assert_eq!(rb1.intersection_len(&rb2), (rb1 & rb2).len());
+    /// ```
+    // TODO convert this into a trait
+    pub fn intersection_with_serialized_unchecked<R>(&self, other: R) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read,
+    {
+        RoaringBitmap::intersection_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn intersection_with_serialized_impl<R, A, AErr, B, BErr>(
+        &self,
+        mut other: R,
+        a: A,
+        b: B,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        // First read the cookie to determine which version of the format we are reading
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = other.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (other.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::new(io::ErrorKind::Other, "unknown cookie value"));
+            }
+        };
+
+        // Read the run container bitmap if necessary
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; (size + 7) / 8];
+            other.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::new(io::ErrorKind::Other, "size is greater than supported"));
+        }
+
+        // Read the container descriptions
+        let mut description_bytes = vec![0u8; size * DESCRIPTION_BYTES];
+        other.read_exact(&mut description_bytes)?;
+        let mut description_bytes: Vec<[u16; 2]> = pod_collect_to_vec(&description_bytes);
+        description_bytes.iter_mut().for_each(|[ref mut k, ref mut c]| {
+            *k = u16::from_le(*k);
+            *c = u16::from_le(*c);
+        });
+
+        if has_offsets {
+            let mut offsets = vec![0u8; size * OFFSET_BYTES];
+            other.read_exact(&mut offsets)?;
+            drop(offsets); // Not useful when deserializing into memory
+        }
+
+        let mut containers = Vec::with_capacity(size);
+        for container in &self.containers {
+            let (i, key, cardinality) =
+                match description_bytes.binary_search_by_key(&container.key, |[k, _]| *k) {
+                    Ok(index) => {
+                        let [key, cardinality] = description_bytes[index];
+                        (index, key, u64::from(cardinality) + 1)
+                    }
+                    Err(_) => continue,
+                };
+
+            // If the run container bitmap is present, check if this container is a run container
+            let is_run_container =
+                run_container_bitmap.as_ref().map_or(false, |bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let mut store = if is_run_container {
+                todo!("support run containers")
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                other.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                other.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            store &= &container.store;
+
+            containers.push(Container { key, store });
+        }
+
+        Ok(RoaringBitmap { containers })
+    }
+}

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -1,10 +1,10 @@
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt};
 use core::convert::Infallible;
-use core::mem;
-use core::ops::RangeInclusive;
 use std::error::Error;
 use std::io::{self, SeekFrom};
+use std::mem;
+use std::ops::RangeInclusive;
 
 use crate::bitmap::container::Container;
 use crate::bitmap::serialization::{
@@ -12,9 +12,6 @@ use crate::bitmap::serialization::{
     SERIAL_COOKIE_NO_RUNCONTAINER,
 };
 use crate::RoaringBitmap;
-
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 
 use super::container::ARRAY_LIMIT;
 use super::store::{ArrayStore, BitmapStore, Store, BITMAP_LENGTH};

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -278,7 +278,6 @@ impl RoaringBitmap {
 }
 
 #[cfg(test)]
-#[cfg(feature = "std")] // We need this to serialize bitmaps
 mod test {
     use crate::RoaringBitmap;
     use proptest::prelude::*;

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -92,9 +92,8 @@ impl RoaringBitmap {
         let mut description_bytes = &description_bytes[..];
 
         if has_offsets {
-            let mut offsets = vec![0u8; size * OFFSET_BYTES];
-            reader.read_exact(&mut offsets)?;
-            drop(offsets); // We could use these offsets but we are lazy
+            // We could use these offsets but we are lazy
+            reader.seek(SeekFrom::Current((size * OFFSET_BYTES) as i64))?;
         }
 
         let mut containers = Vec::new();
@@ -175,10 +174,10 @@ impl RoaringBitmap {
             };
 
             if let Some(container) = container {
-                let mut tmp_container = Container { key, store };
-                tmp_container &= container;
-                if !tmp_container.is_empty() {
-                    containers.push(tmp_container);
+                let mut other_container = Container { key, store };
+                other_container &= container;
+                if !other_container.is_empty() {
+                    containers.push(other_container);
                 }
             }
         }

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -97,7 +97,7 @@ impl RoaringBitmap {
             drop(offsets); // We could use these offsets but we are lazy
         }
 
-        let mut containers = Vec::with_capacity(size);
+        let mut containers = Vec::new();
 
         // Read each container and skip the useless ones
         for i in 0..size {

--- a/src/bitmap/ops_with_serialized.rs
+++ b/src/bitmap/ops_with_serialized.rs
@@ -51,7 +51,7 @@ impl RoaringBitmap {
 
     fn intersection_with_serialized_impl<R, A, AErr, B, BErr>(
         &self,
-        mut other: R,
+        mut reader: R,
         a: A,
         b: B,
     ) -> io::Result<RoaringBitmap>
@@ -64,9 +64,9 @@ impl RoaringBitmap {
     {
         // First read the cookie to determine which version of the format we are reading
         let (size, has_offsets, has_run_containers) = {
-            let cookie = other.read_u32::<LittleEndian>()?;
+            let cookie = reader.read_u32::<LittleEndian>()?;
             if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
-                (other.read_u32::<LittleEndian>()? as usize, true, false)
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
             } else if (cookie as u16) == SERIAL_COOKIE {
                 let size = ((cookie >> 16) + 1) as usize;
                 (size, size >= NO_OFFSET_THRESHOLD, true)
@@ -78,7 +78,7 @@ impl RoaringBitmap {
         // Read the run container bitmap if necessary
         let run_container_bitmap = if has_run_containers {
             let mut bitmap = vec![0u8; (size + 7) / 8];
-            other.read_exact(&mut bitmap)?;
+            reader.read_exact(&mut bitmap)?;
             Some(bitmap)
         } else {
             None
@@ -90,54 +90,75 @@ impl RoaringBitmap {
 
         // Read the container descriptions
         let mut description_bytes = vec![0u8; size * DESCRIPTION_BYTES];
-        other.read_exact(&mut description_bytes)?;
-        let mut description_bytes: Vec<[u16; 2]> = pod_collect_to_vec(&description_bytes);
-        description_bytes.iter_mut().for_each(|[ref mut k, ref mut c]| {
-            *k = u16::from_le(*k);
-            *c = u16::from_le(*c);
-        });
+        reader.read_exact(&mut description_bytes)?;
+        let mut description_bytes = &description_bytes[..];
 
         if has_offsets {
             let mut offsets = vec![0u8; size * OFFSET_BYTES];
-            other.read_exact(&mut offsets)?;
-            drop(offsets); // Not useful when deserializing into memory
+            reader.read_exact(&mut offsets)?;
+            drop(offsets); // We could use these offsets but we are lazy
         }
 
         let mut containers = Vec::with_capacity(size);
-        for container in &self.containers {
-            let (i, key, cardinality) =
-                match description_bytes.binary_search_by_key(&container.key, |[k, _]| *k) {
-                    Ok(index) => {
-                        let [key, cardinality] = description_bytes[index];
-                        (index, key, u64::from(cardinality) + 1)
-                    }
-                    Err(_) => continue,
-                };
+
+        // Read each container
+        for i in 0..size {
+            let key = description_bytes.read_u16::<LittleEndian>()?;
+            let container = match self.containers.binary_search_by_key(&key, |c| c.key) {
+                Ok(index) => self.containers.get(index),
+                Err(_) => None,
+            };
+            let cardinality = u64::from(description_bytes.read_u16::<LittleEndian>()?) + 1;
 
             // If the run container bitmap is present, check if this container is a run container
             let is_run_container =
                 run_container_bitmap.as_ref().map_or(false, |bm| bm[i / 8] & (1 << (i % 8)) != 0);
 
             let mut store = if is_run_container {
-                todo!("support run containers")
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                if container.is_none() {
+                    continue;
+                }
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
             } else if cardinality <= ARRAY_LIMIT {
                 let mut values = vec![0; cardinality as usize];
-                other.read_exact(cast_slice_mut(&mut values))?;
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                if container.is_none() {
+                    continue;
+                }
                 values.iter_mut().for_each(|n| *n = u16::from_le(*n));
                 let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                 Store::Array(array)
             } else {
                 let mut values = Box::new([0; BITMAP_LENGTH]);
-                other.read_exact(cast_slice_mut(&mut values[..]))?;
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                if container.is_none() {
+                    continue;
+                }
                 values.iter_mut().for_each(|n| *n = u64::from_le(*n));
                 let bitmap = b(cardinality, values)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                 Store::Bitmap(bitmap)
             };
 
-            store &= &container.store;
-
-            containers.push(Container { key, store });
+            if let Some(container) = container {
+                store &= &container.store;
+                containers.push(Container { key, store });
+            }
         }
 
         Ok(RoaringBitmap { containers })

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -9,13 +9,13 @@ use crate::bitmap::container::{Container, ARRAY_LIMIT};
 use crate::bitmap::store::{ArrayStore, BitmapStore, Store, BITMAP_LENGTH};
 use crate::RoaringBitmap;
 
-const SERIAL_COOKIE_NO_RUNCONTAINER: u32 = 12346;
-const SERIAL_COOKIE: u16 = 12347;
-const NO_OFFSET_THRESHOLD: usize = 4;
+pub const SERIAL_COOKIE_NO_RUNCONTAINER: u32 = 12346;
+pub const SERIAL_COOKIE: u16 = 12347;
+pub const NO_OFFSET_THRESHOLD: usize = 4;
 
 // Sizes of header structures
-const DESCRIPTION_BYTES: usize = 4;
-const OFFSET_BYTES: usize = 4;
+pub const DESCRIPTION_BYTES: usize = 4;
+pub const OFFSET_BYTES: usize = 4;
 
 impl RoaringBitmap {
     /// Return the size in bytes of the serialized output.

--- a/src/bitmap/store/array_store/mod.rs
+++ b/src/bitmap/store/array_store/mod.rs
@@ -200,6 +200,10 @@ impl ArrayStore {
         self.vec.len() as u64
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.vec.is_empty()
+    }
+
     pub fn min(&self) -> Option<u16> {
         self.vec.first().copied()
     }

--- a/src/bitmap/store/bitmap_store.rs
+++ b/src/bitmap/store/bitmap_store.rs
@@ -241,6 +241,10 @@ impl BitmapStore {
         self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     pub fn min(&self) -> Option<u16> {
         self.bits
             .iter()

--- a/src/bitmap/store/mod.rs
+++ b/src/bitmap/store/mod.rs
@@ -177,6 +177,13 @@ impl Store {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Array(vec) => vec.is_empty(),
+            Bitmap(bits) => bits.is_empty(),
+        }
+    }
+
     pub fn min(&self) -> Option<u16> {
         match self {
             Array(vec) => vec.min(),


### PR DESCRIPTION
This PR is related to #263 and implements methods to do intersections directly with serialized data. This avoids deserializing everything in memory to reduce it just after which drastically reduces the amount of allocated memory and intensive intersection operations.

## To Do
- [x] Improve function documentation.
- [x] Use the containers offsets when available.
- [ ] ~Convert operation methods to use the `BitAndAssign/BitAnd` traits~ (too much work for now, let's ship)