### PR TITLE
Feature Request: `RoaringBitmap::from_lsb0_bytes`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,20 @@ jobs:
           command: test
           args: --features serde
 
+      - name: miri setup
+        if: matrix.rust == 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: setup
+
+      - name: Test bit endian
+        if: matrix.rust == 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --target s390x-unknown-linux-gnu --package roaring --lib -- bitmap::serialization::test::test_from_bitmap_bytes
+
       - name: Test no default features
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test --target s390x-unknown-linux-gnu --package roaring --lib -- bitmap::serialization::test::test_from_bitmap_bytes
+          args: test --target s390x-unknown-linux-gnu --package roaring --lib -- bitmap::serialization::test::test_from_lsb0_bytes
 
       - name: Test no default features
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,22 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Install miri
+        uses: actions-rs/toolchain@v1
+        if: matrix.rust == 'nightly'
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+
+      - name: miri setup
+        uses: actions-rs/cargo@v1
+        if: matrix.rust == 'nightly'
+        with:
+          command: miri
+          args: setup
+
       - name: Fetch
         uses: actions-rs/cargo@v1
         with:
@@ -70,16 +86,9 @@ jobs:
           command: test
           args: --features serde
 
-      - name: miri setup
-        if: matrix.rust == 'nightly'
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: setup
-
       - name: Test bit endian
-        if: matrix.rust == 'nightly'
         uses: actions-rs/cargo@v1
+        if: matrix.rust == 'nightly'
         with:
           command: miri
           args: test --target s390x-unknown-linux-gnu --package roaring --lib -- bitmap::serialization::test::test_from_lsb0_bytes

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -149,7 +149,7 @@ fn creation(c: &mut Criterion) {
 
         group.throughput(Throughput::Elements(dataset.bitmaps.iter().map(|rb| rb.len()).sum()));
 
-        group.bench_function(BenchmarkId::new("from_bitmap_bytes", &dataset.name), |b| {
+        group.bench_function(BenchmarkId::new("from_lsb0_bytes", &dataset.name), |b| {
             let bitmap_bytes = dataset_numbers
                 .iter()
                 .map(|bitmap_numbers| {
@@ -165,7 +165,7 @@ fn creation(c: &mut Criterion) {
                 .collect::<Vec<_>>();
             b.iter(|| {
                 for bitmap_bytes in &bitmap_bytes {
-                    black_box(RoaringBitmap::from_bitmap_bytes(0, bitmap_bytes));
+                    black_box(RoaringBitmap::from_lsb0_bytes(0, bitmap_bytes));
                 }
             })
         });

--- a/roaring/src/bitmap/container.rs
+++ b/roaring/src/bitmap/container.rs
@@ -31,6 +31,13 @@ impl Container {
     pub fn full(key: u16) -> Container {
         Container { key, store: Store::full() }
     }
+    
+    pub fn from_lsb0_bytes(key: u16, bytes: &[u8], byte_offset: usize) -> Option<Self> {
+        Some(Container {
+            key,
+            store: Store::from_lsb0_bytes(bytes, byte_offset)?,
+        })
+    }
 }
 
 impl Container {

--- a/roaring/src/bitmap/container.rs
+++ b/roaring/src/bitmap/container.rs
@@ -31,12 +31,9 @@ impl Container {
     pub fn full(key: u16) -> Container {
         Container { key, store: Store::full() }
     }
-    
+
     pub fn from_lsb0_bytes(key: u16, bytes: &[u8], byte_offset: usize) -> Option<Self> {
-        Some(Container {
-            key,
-            store: Store::from_lsb0_bytes(bytes, byte_offset)?,
-        })
+        Some(Container { key, store: Store::from_lsb0_bytes(bytes, byte_offset)? })
     }
 }
 

--- a/roaring/src/bitmap/serialization.rs
+++ b/roaring/src/bitmap/serialization.rs
@@ -413,10 +413,16 @@ mod test {
         assert_eq!(rb.min(), Some(CONTAINER_OFFSET + 8));
         
         
-        // Ensure we can set the last byte
+        // Ensure we can set the last byte in an array container
         let bytes = [0x80];
         let rb = RoaringBitmap::from_bitmap_bytes(0xFFFFFFF8, &bytes);
         assert_eq!(rb.len(), 1);
+        assert!(rb.contains(u32::MAX));
+        
+        // Ensure we can set the last byte in a bitmap container
+        let bytes = vec![0xFF; 0x1_0000 / 8];
+        let rb = RoaringBitmap::from_bitmap_bytes(0xFFFF0000, &bytes);
+        assert_eq!(rb.len(), 0x1_0000);
         assert!(rb.contains(u32::MAX));
     }
     

--- a/roaring/src/bitmap/serialization.rs
+++ b/roaring/src/bitmap/serialization.rs
@@ -55,12 +55,13 @@ impl RoaringBitmap {
     /// - `offset: u32` - The starting position in the bitmap where the byte slice will be applied, specified in bits.
     ///                   This means that if `offset` is `n`, the first byte in the slice will correspond to the `n`th bit(0-indexed) in the bitmap.
     ///                   Must be a multiple of 8.
-    /// - `bytes: &[u8]` - The byte slice containing the bitmap data. The bytes are interpreted in little-endian order.
+    /// - `bytes: &[u8]` - The byte slice containing the bitmap data. The bytes are interpreted in "Least-Significant-First" bit order.
     ///
     /// # Interpretation of `bytes`
     ///
-    /// The `bytes` slice is interpreted in little-endian order. Each byte is read from least significant bit (LSB) to most significant bit (MSB).
+    /// The `bytes` slice is interpreted in "Least-Significant-First" bit order. Each byte is read from least significant bit (LSB) to most significant bit (MSB).
     /// For example, the byte `0b00000101` represents the bits `1, 0, 1, 0, 0, 0, 0, 0` in that order (see Examples section).
+    ///
     ///
     /// # Panics
     ///

--- a/roaring/src/bitmap/serialization.rs
+++ b/roaring/src/bitmap/serialization.rs
@@ -4,8 +4,8 @@ use crate::RoaringBitmap;
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use core::convert::Infallible;
-use core::ops::RangeInclusive;
 use core::mem::size_of;
+use core::ops::RangeInclusive;
 use std::error::Error;
 use std::io;
 
@@ -132,7 +132,7 @@ impl RoaringBitmap {
 
             start_container += 1;
         }
-        
+
         // Handle all full containers
         for full_container_key in start_container..end_container_inc {
             let (src, rest) = bytes.split_at(BITMAP_LENGTH * size_of::<u64>());
@@ -411,28 +411,27 @@ mod test {
 
         let rb = RoaringBitmap::from_bitmap_bytes(8, &bytes);
         assert_eq!(rb.min(), Some(CONTAINER_OFFSET + 8));
-        
-        
+
         // Ensure we can set the last byte in an array container
         let bytes = [0x80];
         let rb = RoaringBitmap::from_bitmap_bytes(0xFFFFFFF8, &bytes);
         assert_eq!(rb.len(), 1);
         assert!(rb.contains(u32::MAX));
-        
+
         // Ensure we can set the last byte in a bitmap container
         let bytes = vec![0xFF; 0x1_0000 / 8];
         let rb = RoaringBitmap::from_bitmap_bytes(0xFFFF0000, &bytes);
         assert_eq!(rb.len(), 0x1_0000);
         assert!(rb.contains(u32::MAX));
     }
-    
+
     #[test]
     #[should_panic(expected = "multiple of 8")]
     fn test_from_bitmap_bytes_invalid_offset() {
         let bytes = [0x01];
         RoaringBitmap::from_bitmap_bytes(1, &bytes);
     }
-    
+
     #[test]
     #[should_panic(expected = "<= 2^32")]
     fn test_from_bitmap_bytes_overflow() {

--- a/roaring/src/bitmap/serialization.rs
+++ b/roaring/src/bitmap/serialization.rs
@@ -382,8 +382,8 @@ mod test {
         const CONTAINER_OFFSET: u32 = u64::BITS * BITMAP_LENGTH as u32;
         const CONTAINER_OFFSET_IN_BYTES: u32 = CONTAINER_OFFSET / 8;
         let mut bytes = vec![0xff; CONTAINER_OFFSET_IN_BYTES as usize];
-        bytes.extend(&[0x00; CONTAINER_OFFSET_IN_BYTES as usize]);
-        bytes.extend(&[0b00000001, 0b00000010, 0b00000011, 0b00000100]);
+        bytes.extend([0x00; CONTAINER_OFFSET_IN_BYTES as usize]);
+        bytes.extend([0b00000001, 0b00000010, 0b00000011, 0b00000100]);
 
         let offset = 32;
         let rb = RoaringBitmap::from_lsb0_bytes(offset, &bytes);
@@ -405,7 +405,7 @@ mod test {
 
         // Ensure the empty container is not created
         let mut bytes = vec![0x00u8; CONTAINER_OFFSET_IN_BYTES as usize];
-        bytes.extend(&[0xff]);
+        bytes.extend([0xff]);
         let rb = RoaringBitmap::from_lsb0_bytes(0, &bytes);
         assert_eq!(rb.min(), Some(CONTAINER_OFFSET));
 

--- a/roaring/src/bitmap/store/array_store/mod.rs
+++ b/roaring/src/bitmap/store/array_store/mod.rs
@@ -6,8 +6,8 @@ use crate::bitmap::store::array_store::visitor::{CardinalityCounter, VecWriter};
 use core::cmp::Ordering;
 use core::cmp::Ordering::*;
 use core::fmt::{Display, Formatter};
-use core::ops::{BitAnd, BitAndAssign, BitOr, BitXor, RangeInclusive, Sub, SubAssign};
 use core::mem::size_of;
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitXor, RangeInclusive, Sub, SubAssign};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -55,7 +55,7 @@ impl ArrayStore {
 
     pub fn from_lsb0_bytes(bytes: &[u8], byte_offset: usize, bits_set: u64) -> Self {
         type Word = u64;
-        
+
         let mut vec = Vec::with_capacity(bits_set as usize);
 
         let chunks = bytes.chunks_exact(size_of::<Word>());
@@ -76,7 +76,7 @@ impl ArrayStore {
                 byte &= byte - 1;
             }
         }
-        
+
         Self::from_vec_unchecked(vec)
     }
 

--- a/roaring/src/bitmap/store/array_store/mod.rs
+++ b/roaring/src/bitmap/store/array_store/mod.rs
@@ -7,6 +7,7 @@ use core::cmp::Ordering;
 use core::cmp::Ordering::*;
 use core::fmt::{Display, Formatter};
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitXor, RangeInclusive, Sub, SubAssign};
+use core::mem::size_of;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -50,6 +51,33 @@ impl ArrayStore {
         } else {
             ArrayStore { vec }
         }
+    }
+
+    pub fn from_lsb0_bytes(bytes: &[u8], byte_offset: usize, bits_set: u64) -> Self {
+        type Word = u64;
+        
+        let mut vec = Vec::with_capacity(bits_set as usize);
+
+        let chunks = bytes.chunks_exact(size_of::<Word>());
+        let remainder = chunks.remainder();
+        for (index, chunk) in chunks.enumerate() {
+            let bit_index = (byte_offset + index * size_of::<Word>()) * 8;
+            let mut word = Word::from_le_bytes(chunk.try_into().unwrap());
+
+            while word != 0 {
+                vec.push((word.trailing_zeros() + bit_index as u32) as u16);
+                word &= word - 1;
+            }
+        }
+        for (index, mut byte) in remainder.iter().copied().enumerate() {
+            let bit_index = (byte_offset + (bytes.len() - remainder.len()) + index) * 8;
+            while byte != 0 {
+                vec.push((byte.trailing_zeros() + bit_index as u32) as u16);
+                byte &= byte - 1;
+            }
+        }
+        
+        Self::from_vec_unchecked(vec)
     }
 
     #[inline]

--- a/roaring/src/bitmap/store/bitmap_store.rs
+++ b/roaring/src/bitmap/store/bitmap_store.rs
@@ -42,27 +42,41 @@ impl BitmapStore {
     }
 
     pub fn from_lsb0_bytes_unchecked(bytes: &[u8], byte_offset: usize, bits_set: u64) -> Self {
-        assert!(byte_offset + bytes.len() <= BITMAP_LENGTH * size_of::<u64>());
+        const BITMAP_BYTES: usize = BITMAP_LENGTH * size_of::<u64>();
+        assert!(byte_offset.checked_add(bytes.len()).map_or(false, |sum| sum <= BITMAP_BYTES));
 
-        let mut bits = Box::new([0u64; BITMAP_LENGTH]);
-        // Safety: It's safe to reinterpret u64s as u8s because u8 has less alignment requirements,
-        // and has no padding/uninitialized data.
-        let dst = unsafe {
-            std::slice::from_raw_parts_mut(
-                bits.as_mut_ptr().cast::<u8>(),
-                BITMAP_LENGTH * size_of::<u64>(),
-            )
+        // If we know we're writing the full bitmap, we can avoid the initial memset to 0
+        let mut bits = if bytes.len() == BITMAP_BYTES {
+            debug_assert_eq!(byte_offset, 0); // Must be true from the above assert
+
+            // Safety: We've checked that the length is correct, and we use an unaligned load in case
+            //         the bytes are not 8 byte aligned.
+            // The optimizer can see through this, and avoid the double copy to copy directly into
+            // the allocated box from bytes with memcpy
+            let bytes_as_words =
+                unsafe { bytes.as_ptr().cast::<[u64; BITMAP_LENGTH]>().read_unaligned() };
+            Box::new(bytes_as_words)
+        } else {
+            let mut bits = Box::new([0u64; BITMAP_LENGTH]);
+            // Safety: It's safe to reinterpret u64s as u8s because u8 has less alignment requirements,
+            // and has no padding/uninitialized data.
+            let dst = unsafe {
+                std::slice::from_raw_parts_mut(bits.as_mut_ptr().cast::<u8>(), BITMAP_BYTES)
+            };
+            let dst = &mut dst[byte_offset..][..bytes.len()];
+            dst.copy_from_slice(bytes);
+            bits
         };
-        let dst = &mut dst[byte_offset..][..bytes.len()];
-        dst.copy_from_slice(bytes);
 
-        let start_word = byte_offset / size_of::<u64>();
-        let end_word = (byte_offset + bytes.len() + (size_of::<u64>() - 1)) / size_of::<u64>();
+        if !cfg!(target_endian = "little") {
+            // Convert all words we touched (even partially) to little-endian
+            let start_word = byte_offset / size_of::<u64>();
+            let end_word = (byte_offset + bytes.len() + (size_of::<u64>() - 1)) / size_of::<u64>();
 
-        // The 0th byte is the least significant byte, so we've written the bytes in little-endian
-        // order, convert to native endian. Expect this to get optimized away for little-endian.
-        for word in &mut bits[start_word..end_word] {
-            *word = u64::from_le(*word);
+            // The 0th byte is the least significant byte, so we've written the bytes in little-endian
+            for word in &mut bits[start_word..end_word] {
+                *word = u64::from_le(*word);
+            }
         }
 
         Self::from_unchecked(bits_set, bits)

--- a/roaring/src/bitmap/store/mod.rs
+++ b/roaring/src/bitmap/store/mod.rs
@@ -50,6 +50,35 @@ impl Store {
         Store::Bitmap(BitmapStore::full())
     }
 
+    pub fn from_lsb0_bytes(bytes: &[u8], byte_offset: usize) -> Option<Self> {
+        assert!(byte_offset + bytes.len() <= BITMAP_LENGTH * mem::size_of::<u64>());
+
+        // It seems to be pretty considerably faster to count the bits
+        // using u64s than for each byte
+        let bits_set = {
+            let mut bits_set = 0;
+            let chunks = bytes.chunks_exact(mem::size_of::<u64>());
+            let remainder = chunks.remainder();
+            for chunk in chunks {
+                let chunk = u64::from_ne_bytes(chunk.try_into().unwrap());
+                bits_set += u64::from(chunk.count_ones());
+            }
+            for byte in remainder {
+                bits_set += u64::from(byte.count_ones());
+            }
+            bits_set
+        };
+        if bits_set == 0 {
+            return None;
+        }
+
+        Some(if bits_set < ARRAY_LIMIT {
+            Array(ArrayStore::from_lsb0_bytes(bytes, byte_offset, bits_set))
+        } else {
+            Bitmap(BitmapStore::from_lsb0_bytes_unchecked(bytes, byte_offset, bits_set))
+        })
+    }
+
     #[inline]
     pub fn insert(&mut self, index: u16) -> bool {
         match self {


### PR DESCRIPTION
## The Feature Explanation
 - Adding new creation function for `RoaringBitmap`
```rust
 pub fn from_lsb0_bytes(offset: u32, bytes: &[u8]) -> RoaringBitmap
```

## Function Behavior
- Interpret bytes as little endian bytes bitmap, and construct `RoaringBitmap`
- `offset` can be used to offset the passing bitmap's index
- If `offset` is not aligned to # of bits of `Container`'s `Store::Bitmap` (# of bits of `Box<[u64; 1024]>`), this function panics
```rust
use roaring::RoaringBitmap;

let bytes = [0b00000101, 0b00000010, 0b00000000, 0b10000000];
//             ^^^^^^^^    ^^^^^^^^    ^^^^^^^^    ^^^^^^^^
//             76543210          98
let rb = RoaringBitmap::from_lsb0_bytes(0, &bytes);
assert!(rb.contains(0));
assert!(!rb.contains(1));
assert!(rb.contains(2));
assert!(rb.contains(9));
assert!(rb.contains(31));

let rb = RoaringBitmap::from_lsb0_bytes(8, &bytes);
assert!(rb.contains(8));
assert!(!rb.contains(9));
assert!(rb.contains(10));
assert!(rb.contains(17));
assert!(rb.contains(39));
```

## Motivation
Sometimes bitmap is calculated by SIMD instructions. The result of SIMD instruction is likely to be already **bitmask**, not the series of bitmap indicies.

Under current implementation, when you intend use `RoaringBitmap` with **bitmask** produced by SIMD instruction, you have to use `RoaringBitmap::sorted_iter` or just insert one by one.

To solve this problem, I implemented `RoaringBitmap::from_bitmap_bytes`, which can be used to construct directly from **bitmask**.

### Example of Production of Bitmask by SIMD instructions

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=40ddd13554c171be31fe53893401d40f
```rust
use std::arch::x86_64::*;

#[target_feature(enable = "avx2")]
unsafe fn compare_u8_avx2(a: &[u8], b: &[u8]) -> u32 {
    assert!(
        a.len() == 32 && b.len() == 32,
        "Inputs must have a length of 32."
    );

    // Load the data into 256-bit AVX2 registers
    let a_vec = _mm256_loadu_si256(a.as_ptr() as *const __m256i);
    let b_vec = _mm256_loadu_si256(b.as_ptr() as *const __m256i);

    // Perform comparison (a == b)
    let cmp_result = _mm256_cmpeq_epi8(a_vec, b_vec);

    // Extract the comparison result as a bitmask
    let mask = _mm256_movemask_epi8(cmp_result);

    mask as u32
}

fn main() {
    let a: [u8; 32] = [
        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
        26, 27, 28, 29, 30, 31, 32,
    ];
    let b: [u8; 32] = [
        1, 0, 3, 4, 5, 6, 7, 8, 0, 10, 11, 12, 13, 0, 15, 16, 0, 18, 19, 20, 21, 0, 23, 24, 0, 26,
        27, 0, 29, 0, 31, 32,
    ];

    let mask = unsafe {
        compare_u8_avx2(&a, &b)
    };
    println!("Bitmask: {:#034b}", mask);
    // Bitmask: 0b11010110110111101101111011111101
    print!("Bitmask (little endian u8): ");
    for b in mask.to_le_bytes() {
        print!("{:08b} ", b);
    }
    println!();
    // Bitmask (little endian u8): 11111101 11011110 11011110 11010110 
    
    let n = 2;
    println!("Bitmask at {n}: {}", mask & (1 << n) != 0);
    // Bitmask at 2: true
}

``` 

## Benchmark Result
On my laptop (Apple M3 MacBook Air Sonoma14.3 Memory 16 GB), in most cases `from_lsb0_bytes` is much faster than `from_sorted_iter`.
### Part of Results
```
creation/from_bitmap_bytes/census-income_srt                                                                             
                        time:   [984.25 µs 987.00 µs 990.37 µs]
                        thrpt:  [6.1521 Gelem/s 6.1731 Gelem/s 6.1904 Gelem/s]
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
creation/from_sorted_iter/census-income_srt                                                                            
                        time:   [23.383 ms 23.397 ms 23.413 ms]
                        thrpt:  [260.24 Melem/s 260.41 Melem/s 260.57 Melem/s]
```