### PR TITLE
Fix warnings when testing with nightly

### DIFF
--- a/roaring/src/bitmap/arbitrary.rs
+++ b/roaring/src/bitmap/arbitrary.rs
@@ -189,7 +189,7 @@ mod test {
 
     impl RoaringBitmap {
         prop_compose! {
-            pub fn arbitrary()(bitmap in (0usize..=16).prop_flat_map(containers)) -> RoaringBitmap {
+            pub(crate) fn arbitrary()(bitmap in (0usize..=16).prop_flat_map(containers)) -> RoaringBitmap {
                 bitmap
             }
         }

--- a/roaring/src/bitmap/container.rs
+++ b/roaring/src/bitmap/container.rs
@@ -295,7 +295,7 @@ impl IntoIterator for Container {
     }
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = u32;
     fn next(&mut self) -> Option<u32> {
         self.inner.next().map(|i| util::join(self.key, i))

--- a/roaring/src/bitmap/store/mod.rs
+++ b/roaring/src/bitmap/store/mod.rs
@@ -497,7 +497,7 @@ impl PartialEq for Store {
     }
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = u16;
 
     fn next(&mut self) -> Option<u16> {

--- a/roaring/src/treemap/arbitrary.rs
+++ b/roaring/src/treemap/arbitrary.rs
@@ -6,7 +6,7 @@ mod test {
 
     impl RoaringTreemap {
         prop_compose! {
-            pub fn arbitrary()(map in btree_map(0u32..=16, RoaringBitmap::arbitrary(), 0usize..=16)) -> RoaringTreemap {
+            pub(crate) fn arbitrary()(map in btree_map(0u32..=16, RoaringBitmap::arbitrary(), 0usize..=16)) -> RoaringTreemap {
                 // we’re NEVER supposed to start with a treemap containing empty bitmaps
                 // Since we can’t configure this in arbitrary we’re simply going to ignore the generated empty bitmaps
                 let map = map.into_iter().filter(|(_, v)| !v.is_empty()).collect();

--- a/roaring/src/treemap/iter.rs
+++ b/roaring/src/treemap/iter.rs
@@ -11,7 +11,7 @@ struct To64Iter<'a> {
     inner: Iter32<'a>,
 }
 
-impl<'a> Iterator for To64Iter<'a> {
+impl Iterator for To64Iter<'_> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
         self.inner.next().map(|n| util::join(self.hi, n))
@@ -109,7 +109,7 @@ pub struct IntoIter {
     size_hint: u64,
 }
 
-impl<'a> Iter<'a> {
+impl Iter<'_> {
     fn new(map: &BTreeMap<u32, RoaringBitmap>) -> Iter {
         let size_hint: u64 = map.iter().map(|(_, r)| r.len()).sum();
         let i = map.iter().flat_map(to64iter as _);
@@ -125,7 +125,7 @@ impl IntoIter {
     }
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = u64;
 
     fn next(&mut self) -> Option<u64> {


### PR DESCRIPTION
Keep testing arbitrary implementations as pub(crate). This avoids warnings about undocumented public APIs.

Should fix CI issues found in #291, #292, #288