### PR TITLE
Lazily compute Iterator len

### DIFF
--- a/roaring/src/bitmap/container.rs
+++ b/roaring/src/bitmap/container.rs
@@ -300,6 +300,21 @@ impl Iterator for Iter<'_> {
     fn next(&mut self) -> Option<u32> {
         self.inner.next().map(|i| util::join(self.key, i))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.inner.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth(n).map(|i| util::join(self.key, i))
+    }
 }
 
 impl DoubleEndedIterator for Iter<'_> {
@@ -307,6 +322,8 @@ impl DoubleEndedIterator for Iter<'_> {
         self.inner.next_back().map(|i| util::join(self.key, i))
     }
 }
+
+impl ExactSizeIterator for Iter<'_> {}
 
 impl fmt::Debug for Container {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/roaring/src/bitmap/store/bitmap_store.rs
+++ b/roaring/src/bitmap/store/bitmap_store.rs
@@ -449,6 +449,24 @@ impl<B: Borrow<[u64; BITMAP_LENGTH]>> Iterator for BitmapIter<B> {
         self.value &= self.value - 1;
         Some(64 * self.key + index)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut len: u32 = self.value.count_ones();
+        if self.key < self.key_back {
+            for v in &self.bits.borrow()[self.key as usize + 1..self.key_back as usize] {
+                len += v.count_ones();
+            }
+            len += self.value_back.count_ones();
+        }
+        (len as usize, Some(len as usize))
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
+    }
 }
 
 impl<B: Borrow<[u64; BITMAP_LENGTH]>> DoubleEndedIterator for BitmapIter<B> {
@@ -472,6 +490,8 @@ impl<B: Borrow<[u64; BITMAP_LENGTH]>> DoubleEndedIterator for BitmapIter<B> {
         }
     }
 }
+
+impl<B: Borrow<[u64; BITMAP_LENGTH]>> ExactSizeIterator for BitmapIter<B> {}
 
 #[inline]
 pub fn key(index: u16) -> usize {

--- a/roaring/src/bitmap/store/mod.rs
+++ b/roaring/src/bitmap/store/mod.rs
@@ -508,6 +508,36 @@ impl Iterator for Iter<'_> {
             Iter::BitmapOwned(inner) => inner.next(),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Iter::Array(inner) => inner.size_hint(),
+            Iter::Vec(inner) => inner.size_hint(),
+            Iter::BitmapBorrowed(inner) => inner.size_hint(),
+            Iter::BitmapOwned(inner) => inner.size_hint(),
+        }
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        match self {
+            Iter::Array(inner) => inner.count(),
+            Iter::Vec(inner) => inner.count(),
+            Iter::BitmapBorrowed(inner) => inner.count(),
+            Iter::BitmapOwned(inner) => inner.count(),
+        }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        match self {
+            Iter::Array(inner) => inner.nth(n).copied(),
+            Iter::Vec(inner) => inner.nth(n),
+            Iter::BitmapBorrowed(inner) => inner.nth(n),
+            Iter::BitmapOwned(inner) => inner.nth(n),
+        }
+    }
 }
 
 impl DoubleEndedIterator for Iter<'_> {
@@ -520,3 +550,5 @@ impl DoubleEndedIterator for Iter<'_> {
         }
     }
 }
+
+impl ExactSizeIterator for Iter<'_> {}


### PR DESCRIPTION
Lazily compute the length of an iterator, rather than doing so eagerly at creation time.

Additionally, add more efficient implementations of `count`, `nth`, and `nth_back`.

This required somewhat manually reimplementing `std::iter::Flatten`, but this is something we'll need to do anyway for #290 / #287.

This is currently built on top of #292, (so the PR currently includes commits from that PR too)

Fixes #294 