### PR TITLE
Bump version to v0.10.7

### DIFF
--- a/roaring/Cargo.toml
+++ b/roaring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roaring"
-version = "0.10.6"
+version = "0.10.7"
 rust-version = "1.65.0"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "A better compressed bitset - pure Rust implementation"
@@ -30,4 +30,3 @@ std = ["dep:bytemuck", "dep:byteorder"]
 proptest = { workspace = true }
 serde_json = { workspace = true }
 bincode = { workspace = true }
-


### PR DESCRIPTION
This PR bumps the roaring version to v0.10.7 to be able to release a lot of new features and improvements.