### PR TITLE
chore(deps): replace `bincode` with `postcard`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,10 @@
 [workspace]
-members = ["roaring", "benchmarks"]
+members = [ "benchmarks", "roaring" ]
 resolver = "2"
 
 [workspace.dependencies]
 roaring = { path = "roaring" }
 
-bincode = "1.3.3"
 bytemuck = "1.21.0"
 byteorder = "1.5.0"
 criterion = "0.5"
@@ -13,9 +12,10 @@ git2 = { version = "0.20", default-features = false }
 indicatif = "0.17"
 itertools = "0.14"
 once_cell = "1.20"
+postcard = { version = "1.1", features = [ "alloc" ] }
 proptest = "1.6.0"
 serde = "1.0.217"
-serde_json = "1.0.135"
+serde_json = "1.0.138"
 zip = { version = "0.6", default-features = false }
 
 [profile.test]

--- a/roaring/Cargo.toml
+++ b/roaring/Cargo.toml
@@ -29,4 +29,4 @@ std = ["dep:bytemuck", "dep:byteorder"]
 [dev-dependencies]
 proptest = { workspace = true }
 serde_json = { workspace = true }
-bincode = { workspace = true }
+postcard = { workspace = true }

--- a/roaring/src/bitmap/multiops.rs
+++ b/roaring/src/bitmap/multiops.rs
@@ -332,7 +332,7 @@ fn try_multi_or_ref<'a, E: 'a>(
     // Phase 3: Clean up
     let containers: Vec<_> = containers
         .into_iter()
-        .filter(|container| container.len() > 0)
+        .filter(|container| !container.is_empty())
         .map(|c| {
             // Any borrowed bitmaps or arrays left over get cloned here
             let mut container = c.into_owned();
@@ -373,7 +373,7 @@ fn try_multi_xor_ref<'a, E: 'a>(
     // Phase 3: Clean up
     let containers: Vec<_> = containers
         .into_iter()
-        .filter(|container| container.len() > 0)
+        .filter(|container| !container.is_empty())
         .map(|c| {
             // Any borrowed bitmaps or arrays left over get cloned here
             let mut container = c.into_owned();

--- a/roaring/src/bitmap/serde.rs
+++ b/roaring/src/bitmap/serde.rs
@@ -72,11 +72,11 @@ mod test {
         }
 
         #[test]
-        fn test_bincode(
+        fn test_postcard(
             bitmap in RoaringBitmap::arbitrary(),
         ) {
-            let buffer = bincode::serialize(&bitmap).unwrap();
-            prop_assert_eq!(bitmap, bincode::deserialize(&buffer).unwrap());
+            let buffer = postcard::to_allocvec(&bitmap).unwrap();
+            prop_assert_eq!(bitmap, postcard::from_bytes(&buffer).unwrap());
         }
     }
 }

--- a/roaring/src/lib.rs
+++ b/roaring/src/lib.rs
@@ -13,6 +13,7 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 #![warn(variant_size_differences)]
 #![allow(unknown_lints)] // For clippy
+#![allow(clippy::doc_overindented_list_items)]
 
 #[cfg(feature = "std")]
 extern crate byteorder;

--- a/roaring/src/treemap/serde.rs
+++ b/roaring/src/treemap/serde.rs
@@ -72,11 +72,11 @@ mod test {
         }
 
         #[test]
-        fn test_bincode(
+        fn test_postcard(
             treemap in RoaringTreemap::arbitrary(),
         ) {
-            let buffer = bincode::serialize(&treemap).unwrap();
-            prop_assert_eq!(treemap, bincode::deserialize(&buffer).unwrap());
+            let buffer = postcard::to_allocvec(&treemap).unwrap();
+            prop_assert_eq!(treemap, postcard::from_bytes(&buffer).unwrap());
         }
     }
 }


### PR DESCRIPTION
motivations:

- `bincode` has not released a new version for over a year, and many plans for v2.0 have yet to be implemented.
- `postcard` is in better maintenance condition and is sufficiently suitable for testing purposes.