### PR TITLE
chore: deny unnameable types by default

### DIFF
--- a/roaring/src/bitmap/container.rs
+++ b/roaring/src/bitmap/container.rs
@@ -1,3 +1,5 @@
+// TODO: remove the line below and document `Container` and `Iter` or make them not pub
+#![allow(unnameable_types)]
 use core::fmt;
 use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, RangeInclusive, Sub, SubAssign,

--- a/roaring/src/bitmap/store/mod.rs
+++ b/roaring/src/bitmap/store/mod.rs
@@ -1,3 +1,5 @@
+// TODO: remove the line below and document the pub structs in this module or make them not pub
+#![allow(unnameable_types)]
 mod array_store;
 mod bitmap_store;
 

--- a/roaring/src/lib.rs
+++ b/roaring/src/lib.rs
@@ -14,6 +14,7 @@
 #![warn(variant_size_differences)]
 #![allow(unknown_lints)] // For clippy
 #![allow(clippy::doc_overindented_list_items)]
+#![deny(unnameable_types)]
 
 #[cfg(feature = "std")]
 extern crate byteorder;

--- a/roaring/src/treemap/iter.rs
+++ b/roaring/src/treemap/iter.rs
@@ -415,6 +415,7 @@ impl RoaringTreemap {
     }
 }
 
+/// An iterator of `RoaringBitmap`s for `RoaringTreemap`.
 pub struct BitmapIter<'a>(btree_map::Iter<'a, u32, RoaringBitmap>);
 
 impl<'a> Iterator for BitmapIter<'a> {

--- a/roaring/src/treemap/mod.rs
+++ b/roaring/src/treemap/mod.rs
@@ -17,7 +17,7 @@ mod serde;
 #[cfg(feature = "std")]
 mod serialization;
 
-pub use self::iter::{IntoIter, Iter};
+pub use self::iter::{BitmapIter, IntoIter, Iter};
 
 /// A compressed bitmap with u64 values.
 /// Implemented as a `BTreeMap` of `RoaringBitmap`s.


### PR DESCRIPTION
Set the `unnameable-types` lint to deny so that structs, types and enums declared as `pub` that aren't actually accessible from outside the crate causes a lint error.

The `store` and `container` modules have been excluded and left for a follow-up - I'm not familiar enough with this repo to do a good job at documenting them yet.

Partially addresses the comments on https://github.com/RoaringBitmap/roaring-rs/issues/312.



