### PR TITLE
Disallow `todo!`s through a new Clippy rule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,10 @@ jobs:
         # so we don't need to run `cargo check` or `cargo build`
         # use different features to check if everything is fine
         # the incremental compilation will make this faster
+        # We disallow todo!s in the code too.
         run: |
           cargo clippy -p roaring --all-targets --no-default-features -- -D warnings
-          cargo clippy -p roaring --all-targets --features serde -- -D warnings
+          cargo clippy -p roaring --all-targets --features serde -- -Dclippy::todo -D warnings
 
       - name: Check SIMD
         if: matrix.rust == 'nightly'


### PR DESCRIPTION
This PR changes the CI by [disallowing `todo!`s](https://rust-lang.github.io/rust-clippy/master/index.html#todo) in the code through [the command line argument](https://doc.rust-lang.org/clippy/usage.html#command-line).

It will compile once we remove the `todo!`s. [See related comment](https://github.com/RoaringBitmap/roaring-rs/pull/314#issuecomment-2775434442).