### PR TITLE
Include license files in published crate

### DIFF
--- a/roaring/LICENSE-APACHE
+++ b/roaring/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/roaring/LICENSE-MIT
+++ b/roaring/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Hi, thanks for this library! This PR symlinks the license files so they're included in the published crate.

```sh
cd roaring
ln -s ../LICENSE-APACHE .
ln -s ../LICENSE-MIT .   
```