### PR TITLE
Change the API of the push method to return a result

### DIFF
--- a/roaring/src/bitmap/inherent.rs
+++ b/roaring/src/bitmap/inherent.rs
@@ -316,7 +316,30 @@ impl RoaringBitmap {
     /// assert_eq!(rb.iter().collect::<Vec<u32>>(), vec![1, 3, 5]);
     /// ```
     #[inline]
-    pub fn push(&mut self, value: u32) -> Result<(), IntegerTooSmall> {
+    #[deprecated(since = "0.11.0", note = "use `try_push` instead")]
+    pub fn push(&mut self, value: u32) -> bool {
+        self.try_push(value).is_ok()
+    }
+
+    /// Pushes `value` in the bitmap only if it is greater than the current maximum value.
+    ///
+    /// Returns an error if the value is not greater than the current maximum value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::{RoaringBitmap, IntegerTooSmall};
+    ///
+    /// let mut rb = RoaringBitmap::new();
+    /// assert!(rb.try_push(1).is_ok());
+    /// assert!(rb.try_push(3).is_ok());
+    /// assert_eq!(rb.try_push(3), Err(IntegerTooSmall));
+    /// assert!(rb.try_push(5).is_ok());
+    ///
+    /// assert_eq!(rb.iter().collect::<Vec<u32>>(), vec![1, 3, 5]);
+    /// ```
+    #[inline]
+    pub fn try_push(&mut self, value: u32) -> Result<(), IntegerTooSmall> {
         let (key, index) = util::split(value);
 
         match self.containers.last_mut() {

--- a/roaring/src/lib.rs
+++ b/roaring/src/lib.rs
@@ -33,6 +33,16 @@ pub mod treemap;
 pub use bitmap::RoaringBitmap;
 pub use treemap::RoaringTreemap;
 
+/// An error type that is returned when a push in a bitmap did not succeed.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct IntegerTooSmall;
+
+impl fmt::Display for IntegerTooSmall {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("inserted integer is smaller than the largest integer")
+    }
+}
+
 /// An error type that is returned when an iterator isn't sorted.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonSortedIntegers {

--- a/roaring/src/lib.rs
+++ b/roaring/src/lib.rs
@@ -33,7 +33,7 @@ pub mod treemap;
 pub use bitmap::RoaringBitmap;
 pub use treemap::RoaringTreemap;
 
-/// An error type that is returned when a push in a bitmap did not succeed.
+/// An error type that is returned when a `try_push` in a bitmap did not succeed.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IntegerTooSmall;
 

--- a/roaring/src/treemap/inherent.rs
+++ b/roaring/src/treemap/inherent.rs
@@ -2,6 +2,7 @@ use alloc::collections::btree_map::{BTreeMap, Entry};
 use core::iter;
 use core::ops::RangeBounds;
 
+use crate::IntegerTooSmall;
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;
 
@@ -123,7 +124,7 @@ impl RoaringTreemap {
     ///
     /// assert_eq!(rb.iter().collect::<Vec<u64>>(), vec![1, 3, 5]);
     /// ```
-    pub fn push(&mut self, value: u64) -> bool {
+    pub fn push(&mut self, value: u64) -> Result<(), IntegerTooSmall> {
         let (hi, lo) = util::split(value);
         self.map.entry(hi).or_default().push(lo)
     }

--- a/roaring/src/treemap/inherent.rs
+++ b/roaring/src/treemap/inherent.rs
@@ -124,9 +124,32 @@ impl RoaringTreemap {
     ///
     /// assert_eq!(rb.iter().collect::<Vec<u64>>(), vec![1, 3, 5]);
     /// ```
-    pub fn push(&mut self, value: u64) -> Result<(), IntegerTooSmall> {
+    #[deprecated(since = "0.11.0", note = "use `try_push` instead")]
+    pub fn push(&mut self, value: u64) -> bool {
         let (hi, lo) = util::split(value);
-        self.map.entry(hi).or_default().push(lo)
+        self.map.entry(hi).or_default().try_push(lo).is_ok()
+    }
+
+    /// Pushes `value` in the treemap only if it is greater than the current maximum value.
+    ///
+    /// Returns an error if the value is not greater than the current maximum value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::{RoaringTreemap, IntegerTooSmall};
+    ///
+    /// let mut rb = RoaringTreemap::new();
+    /// assert!(rb.try_push(1).is_ok());
+    /// assert!(rb.try_push(3).is_ok());
+    /// assert_eq!(rb.try_push(3), Err(IntegerTooSmall));
+    /// assert!(rb.try_push(5).is_ok());
+    ///
+    /// assert_eq!(rb.iter().collect::<Vec<u64>>(), vec![1, 3, 5]);
+    /// ```
+    pub fn try_push(&mut self, value: u64) -> Result<(), IntegerTooSmall> {
+        let (hi, lo) = util::split(value);
+        self.map.entry(hi).or_default().try_push(lo)
     }
 
     /// Pushes `value` in the treemap only if it is greater than the current maximum value.


### PR DESCRIPTION
This PR improves the API to ensure we don't make the same mistake of forgetting to check the boolean returned by the `push` method. We made multiple mistakes previously at Meilisearch, so I think the best approach is to deprecate it and introduce a new `try_push` method that returns a `Result`.