### PR TITLE
fix: change `package.rust-version` in `roaring/Cargo.toml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
           - stable
           - beta
           - nightly
+          # When changing this value don't forget to change the `package.rust-version` field in
+          # `roaring/Cargo.toml`!!!
           - 1.80.1
     env:
       RUSTFLAGS: "-C target-cpu=native -C opt-level=3"

--- a/roaring/Cargo.toml
+++ b/roaring/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "roaring"
 version = "0.11.1"
-rust-version = "1.65.0"
+# When changing this value don't forget to change the MSRV test in `.github/workflows/test.yml`!!
+rust-version = "1.80.1"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "A better compressed bitset - pure Rust implementation"
 


### PR DESCRIPTION
Changes the MSRV of the roaring crate in the Cargo.toml to reflect the change to the MSRV in the ci.
Also adds warning comments, so future changes to either hopefully stay in sync.