### PR TITLE
fix: bitmap advance_back_to could violate invariants

### DIFF
--- a/roaring/src/bitmap/store/bitmap_store.rs
+++ b/roaring/src/bitmap/store/bitmap_store.rs
@@ -551,7 +551,11 @@ impl<B: Borrow<[u64; BITMAP_LENGTH]>> BitmapIter<B> {
                 } else if cmp == Ordering::Equal {
                     (self.value, &mut self.value)
                 } else {
-                    (0, &mut self.value)
+                    // New key is less than original key and key_back, this iterator is now empty
+                    self.key_back = self.key;
+                    self.value = 0;
+                    self.value_back = 0;
+                    return;
                 }
             }
         };

--- a/roaring/tests/iter_advance_to.rs
+++ b/roaring/tests/iter_advance_to.rs
@@ -298,3 +298,16 @@ fn advance_bitset_front_and_back_past_each_other() {
     iter.advance_to(300);
     assert_eq!(iter.next(), None);
 }
+
+#[test]
+fn combine_with_nth() {
+    let mut bitmap = RoaringBitmap::new();
+    bitmap.insert_range(0..=0xFFFF);
+    bitmap.remove_run_compression();
+    let mut iter = bitmap.iter();
+
+    // Use nth to skip to a specific position
+    assert_eq!(iter.nth(100), Some(100));
+    iter.advance_back_to(50);
+    assert_eq!(iter.next_back(), None);
+}


### PR DESCRIPTION
Bitmap container iterators require the front key <= the back key at all times, but advance_back_to could violate this. This shouldn't have really caused any misbehavior, but would trigger a debug assertion.