### PR TITLE
Remove SIMD LaneCount, SupportedLaneCount with upstream changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - nightly
           # When changing this value don't forget to change the `package.rust-version` field in
           # `roaring/Cargo.toml`!!!
-          - 1.82.0
+          - 1.90.0
     env:
       RUSTFLAGS: "-C target-cpu=native -C opt-level=3"
 
@@ -64,7 +64,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.82.0
+          - 1.90.0
         features:
           - default
           - no-std
@@ -98,7 +98,7 @@ jobs:
         run: cargo test -p roaring --features serde
 
       - name: Test Benches
-        if: matrix.rust != '1.82.0' && matrix.features == 'default'
+        if: matrix.rust != '1.90.0' && matrix.features == 'default'
         run: cargo test -p benchmarks --benches
 
       - name: Test no default features

--- a/roaring/Cargo.toml
+++ b/roaring/Cargo.toml
@@ -2,7 +2,7 @@
 name = "roaring"
 version = "0.11.3"
 # When changing this value don't forget to change the MSRV test in `.github/workflows/test.yml`!!
-rust-version = "1.82.0"
+rust-version = "1.90.0"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "A better compressed bitset - pure Rust implementation"
 

--- a/roaring/src/bitmap/inherent.rs
+++ b/roaring/src/bitmap/inherent.rs
@@ -101,7 +101,7 @@ impl RoaringBitmap {
 
             result
         }
-        if offset % 8 != 0 {
+        if !offset.is_multiple_of(8) {
             let shift = offset as usize % 8;
             let shifted_bytes = shift_bytes(bytes, shift);
             return RoaringBitmap::from_lsb0_bytes(offset - shift as u32, &shifted_bytes);

--- a/roaring/src/bitmap/store/array_store/vector.rs
+++ b/roaring/src/bitmap/store/array_store/vector.rs
@@ -12,9 +12,7 @@
 
 use super::scalar;
 use core::simd::cmp::{SimdPartialEq, SimdPartialOrd};
-use core::simd::{
-    mask16x8, u16x8, u8x16, LaneCount, Mask, Simd, SimdElement, SupportedLaneCount, ToBytes,
-};
+use core::simd::{mask16x8, u16x8, u8x16, Mask, Select as _, Simd, SimdElement, ToBytes};
 
 // a one-pass SSE union algorithm
 pub fn or(lhs: &[u16], rhs: &[u16], visitor: &mut impl BinaryOperationVisitor) {
@@ -360,10 +358,7 @@ pub fn sub(lhs: &[u16], rhs: &[u16], visitor: &mut impl BinaryOperationVisitor) 
 fn lanes_min_u16<const LANES: usize>(
     lhs: Simd<u16, LANES>,
     rhs: Simd<u16, LANES>,
-) -> Simd<u16, LANES>
-where
-    LaneCount<LANES>: SupportedLaneCount,
-{
+) -> Simd<u16, LANES> {
     lhs.simd_le(rhs).select(lhs, rhs)
 }
 
@@ -372,10 +367,7 @@ where
 fn lanes_max_u16<const LANES: usize>(
     lhs: Simd<u16, LANES>,
     rhs: Simd<u16, LANES>,
-) -> Simd<u16, LANES>
-where
-    LaneCount<LANES>: SupportedLaneCount,
-{
+) -> Simd<u16, LANES> {
     lhs.simd_gt(rhs).select(lhs, rhs)
 }
 
@@ -383,7 +375,6 @@ where
 pub fn load<U, const LANES: usize>(src: &[U]) -> Simd<U, LANES>
 where
     U: SimdElement + PartialOrd,
-    LaneCount<LANES>: SupportedLaneCount,
 {
     debug_assert!(src.len() >= LANES);
     unsafe { load_unchecked(src) }
@@ -397,7 +388,6 @@ where
 pub unsafe fn load_unchecked<U, const LANES: usize>(src: &[U]) -> Simd<U, LANES>
 where
     U: SimdElement + PartialOrd,
-    LaneCount<LANES>: SupportedLaneCount,
 {
     unsafe { core::ptr::read_unaligned(src as *const _ as *const Simd<U, LANES>) }
 }
@@ -407,7 +397,6 @@ where
 pub fn store<U, const LANES: usize>(v: Simd<U, LANES>, out: &mut [U])
 where
     U: SimdElement + PartialOrd,
-    LaneCount<LANES>: SupportedLaneCount,
 {
     debug_assert!(out.len() >= LANES);
     unsafe {
@@ -423,7 +412,6 @@ where
 unsafe fn store_unchecked<U, const LANES: usize>(v: Simd<U, LANES>, out: &mut [U])
 where
     U: SimdElement + PartialOrd,
-    LaneCount<LANES>: SupportedLaneCount,
 {
     unsafe { core::ptr::write_unaligned(out as *mut _ as *mut Simd<U, LANES>, v) }
 }


### PR DESCRIPTION
Not sure exactly when this will be part of a versioned release? As such this is marked draft. This contains the required changes for SIMD compilation on the latest nightly toolchain.

See https://github.com/rust-lang/rust/commit/b71ff51277dbd5907a7a8089b5d926a02e53d44d.