### PR TITLE
Bump MSRV to v1.90.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - nightly
           # When changing this value don't forget to change the `package.rust-version` field in
           # `roaring/Cargo.toml`!!!
-          - 1.82.0
+          - 1.90.0
     env:
       RUSTFLAGS: "-C target-cpu=native -C opt-level=3"
 
@@ -64,7 +64,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.82.0
+          - 1.90.0
         features:
           - default
           - no-std
@@ -98,7 +98,7 @@ jobs:
         run: cargo test -p roaring --features serde
 
       - name: Test Benches
-        if: matrix.rust != '1.82.0' && matrix.features == 'default'
+        if: matrix.rust != '1.90.0' && matrix.features == 'default'
         run: cargo test -p benchmarks --benches
 
       - name: Test no default features

--- a/roaring/Cargo.toml
+++ b/roaring/Cargo.toml
@@ -2,7 +2,7 @@
 name = "roaring"
 version = "0.11.3"
 # When changing this value don't forget to change the MSRV test in `.github/workflows/test.yml`!!
-rust-version = "1.82.0"
+rust-version = "1.90.0"
 authors = ["Wim Looman <wim@nemo157.com>", "Kerollmops <kero@meilisearch.com>"]
 description = "A better compressed bitset - pure Rust implementation"
 

--- a/roaring/src/bitmap/inherent.rs
+++ b/roaring/src/bitmap/inherent.rs
@@ -101,7 +101,7 @@ impl RoaringBitmap {
 
             result
         }
-        if offset % 8 != 0 {
+        if !offset.is_multiple_of(8) {
             let shift = offset as usize % 8;
             let shifted_bytes = shift_bytes(bytes, shift);
             return RoaringBitmap::from_lsb0_bytes(offset - shift as u32, &shifted_bytes);


### PR DESCRIPTION
Trying to fix the CI of #348 by bumping the version to v1.90.0.