### PR TITLE
Complete the *_with_serialized family with in-place assign variants

### DIFF
--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -599,6 +599,12 @@ fn intersection_with_serialized(c: &mut Criterion) {
     })
 }
 
+fn union_with_serialized(c: &mut Criterion) {
+    pairwise_ops_with_serialized(c, "union_with_serialized_unchecked", |a, b| {
+        a.union_with_serialized_unchecked(Cursor::new(b)).unwrap()
+    })
+}
+
 // LEGACY BENCHMARKS
 // =================
 
@@ -784,5 +790,6 @@ criterion_group!(
     successive_and,
     successive_or,
     intersection_with_serialized,
+    union_with_serialized
 );
 criterion_main!(benches);

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use std::cmp::Reverse;
+use std::io::Cursor;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use criterion::measurement::Measurement;
@@ -666,14 +667,8 @@ fn intersection_with_serialized(c: &mut Criterion) {
     pairwise_ops_with_serialized(
         c,
         "intersection_with_serialized",
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            a & &rhs
-        },
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *a &= &rhs;
-        },
+        |a, b| a.intersection_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |a, b| a.intersection_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
     )
 }
 
@@ -681,14 +676,8 @@ fn union_with_serialized(c: &mut Criterion) {
     pairwise_ops_with_serialized(
         c,
         "union_with_serialized",
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            a | &rhs
-        },
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *a |= &rhs;
-        },
+        |a, b| a.union_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |a, b| a.union_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
     )
 }
 
@@ -696,14 +685,8 @@ fn difference_with_serialized(c: &mut Criterion) {
     pairwise_ops_with_serialized(
         c,
         "difference_with_serialized",
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            a - &rhs
-        },
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *a -= &rhs;
-        },
+        |a, b| a.difference_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |a, b| a.difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
     )
 }
 
@@ -711,14 +694,8 @@ fn symmetric_difference_with_serialized(c: &mut Criterion) {
     pairwise_ops_with_serialized(
         c,
         "symmetric_difference_with_serialized",
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            a ^ &rhs
-        },
-        |a, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *a ^= &rhs;
-        },
+        |a, b| a.symmetric_difference_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |a, b| a.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
     )
 }
 
@@ -726,14 +703,8 @@ fn successive_and_with_serialized(c: &mut Criterion) {
     successive_ops_with_serialized(
         c,
         "Successive And With Serialized",
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc = &*acc & &rhs;
-        },
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc &= &rhs;
-        },
+        |acc, b| *acc = acc.intersection_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |acc, b| acc.intersection_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 
@@ -741,14 +712,8 @@ fn successive_or_with_serialized(c: &mut Criterion) {
     successive_ops_with_serialized(
         c,
         "Successive Or With Serialized",
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc = &*acc | &rhs;
-        },
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc |= &rhs;
-        },
+        |acc, b| *acc = acc.union_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |acc, b| acc.union_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 
@@ -756,14 +721,8 @@ fn successive_sub_with_serialized(c: &mut Criterion) {
     successive_ops_with_serialized(
         c,
         "Successive Sub With Serialized",
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc = &*acc - &rhs;
-        },
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc -= &rhs;
-        },
+        |acc, b| *acc = acc.difference_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |acc, b| acc.difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 
@@ -771,14 +730,8 @@ fn successive_xor_with_serialized(c: &mut Criterion) {
     successive_ops_with_serialized(
         c,
         "Successive Xor With Serialized",
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc = &*acc ^ &rhs;
-        },
-        |acc, b| {
-            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
-            *acc ^= &rhs;
-        },
+        |acc, b| *acc = acc.symmetric_difference_with_serialized_unchecked(Cursor::new(b)).unwrap(),
+        |acc, b| acc.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
 use std::cmp::Reverse;
-use std::io::Cursor;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use criterion::measurement::Measurement;
@@ -118,35 +117,105 @@ fn pairwise_binary_op_matrix(
     group.finish();
 }
 
+// Pairwise compare frame for the *_with_serialized evaluation: natural pair
+// order (first bitmap of each pair is the materialized lhs, second is the
+// serialized rhs — no small/large swap), serialization outside the timed
+// setup, one group per op with a "ref_ref" (borrowing) and an "assign_ref"
+// (in-place) bench per group. This commit sits BEFORE the *_with_serialized
+// implementations land, so both slots run the deserialize baselines; a later
+// commit switches the slots to the ws / ws_assign implementations, and
+// criterion's saved-baseline comparison reports the change per slot.
 fn pairwise_ops_with_serialized(
     c: &mut Criterion,
     op_name: &str,
-    op_ref_own: fn(&RoaringBitmap, &[u8]) -> RoaringBitmap,
+    op_ref_ref: fn(&RoaringBitmap, &[u8]) -> RoaringBitmap,
+    op_assign_ref: fn(&mut RoaringBitmap, &[u8]) -> (),
 ) {
     let mut group = c.benchmark_group(format!("pairwise_{op_name}"));
 
     for dataset in Datasets {
-        let pairs = dataset.bitmaps.iter().cloned().tuple_windows::<(_, _)>().collect::<Vec<_>>();
+        let pairs = dataset.bitmaps.iter().tuple_windows::<(_, _)>()
+            .map(|(a, b)| {
+                let mut buf = Vec::new();
+                b.serialize_into(&mut buf).unwrap();
+                (a.clone(), Box::from(buf))
+            })
+            .collect::<Vec<_>>();
 
-        group.bench_function(BenchmarkId::new("ref_own", &dataset.name), |b| {
-            b.iter_batched(
-                || {
-                    pairs
-                        .iter()
-                        .map(|(a, b)| {
-                            let mut buf = Vec::new();
-                            b.serialize_into(&mut buf).unwrap();
-                            (a.clone(), buf)
-                        })
-                        .collect::<Vec<_>>()
-                },
+        group.bench_function(BenchmarkId::new("ref_ref", &dataset.name), |b| {
+            b.iter_batched_ref(
+                || pairs.clone(),
                 |bitmaps| {
                     for (a, b) in bitmaps {
-                        black_box(op_ref_own(&a, &b));
+                        black_box(op_ref_ref(a, b));
                     }
                 },
                 BatchSize::SmallInput,
             );
+        });
+
+        group.bench_function(BenchmarkId::new("assign_ref", &dataset.name), |b| {
+            b.iter_batched_ref(
+                || pairs.clone(),
+                |bitmaps| {
+                    for (a, b) in bitmaps {
+                        black_box(op_assign_ref(a, b));
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+// Successive chains for the *_with_serialized evaluation, same shape as
+// pairwise_ops_with_serialized: fold every bitmap but the first into an
+// accumulator seeded from the first bitmap (all four ops need a non-empty
+// seed for a uniform shape), one group per op, "ref_ref" (borrowing chain,
+// per-step result assigned back) and "assign_ref" (in-place chain) benches
+// per group. Before the ws implementations land, both chains run the
+// deserialize baselines; a later commit switches them to ws / ws_assign.
+fn successive_ops_with_serialized(
+    c: &mut Criterion,
+    group_name: &str,
+    op_ref_ref: fn(&mut RoaringBitmap, &[u8]),
+    op_assign_ref: fn(&mut RoaringBitmap, &[u8]),
+) {
+    let mut group = c.benchmark_group(group_name);
+
+    for dataset in Datasets {
+        let first = dataset.bitmaps[0].clone();
+        let serialized: Vec<Box<[u8]>> = dataset
+            .bitmaps
+            .iter()
+            .skip(1)
+            .map(|b| {
+                let mut buf = Vec::new();
+                b.serialize_into(&mut buf).unwrap();
+                Box::from(buf)
+            })
+            .collect();
+
+        group.bench_function(BenchmarkId::new("ref_ref", &dataset.name), |b| {
+            b.iter(|| {
+                let mut acc = first.clone();
+                for bytes in &serialized {
+                    op_ref_ref(&mut acc, bytes.as_ref());
+                }
+                black_box(&acc);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("assign_ref", &dataset.name), |b| {
+            b.iter(|| {
+                let mut acc = first.clone();
+                for bytes in &serialized {
+                    op_assign_ref(&mut acc, bytes.as_ref());
+                }
+                black_box(&acc);
+            });
         });
     }
 
@@ -594,15 +663,123 @@ fn successive_or(c: &mut Criterion) {
 }
 
 fn intersection_with_serialized(c: &mut Criterion) {
-    pairwise_ops_with_serialized(c, "intersection_with_serialized_unchecked", |a, b| {
-        a.intersection_with_serialized_unchecked(Cursor::new(b)).unwrap()
-    })
+    pairwise_ops_with_serialized(
+        c,
+        "intersection_with_serialized",
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            a & &rhs
+        },
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *a &= &rhs;
+        },
+    )
 }
 
 fn union_with_serialized(c: &mut Criterion) {
-    pairwise_ops_with_serialized(c, "union_with_serialized_unchecked", |a, b| {
-        a.union_with_serialized_unchecked(Cursor::new(b)).unwrap()
-    })
+    pairwise_ops_with_serialized(
+        c,
+        "union_with_serialized",
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            a | &rhs
+        },
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *a |= &rhs;
+        },
+    )
+}
+
+fn difference_with_serialized(c: &mut Criterion) {
+    pairwise_ops_with_serialized(
+        c,
+        "difference_with_serialized",
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            a - &rhs
+        },
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *a -= &rhs;
+        },
+    )
+}
+
+fn symmetric_difference_with_serialized(c: &mut Criterion) {
+    pairwise_ops_with_serialized(
+        c,
+        "symmetric_difference_with_serialized",
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            a ^ &rhs
+        },
+        |a, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *a ^= &rhs;
+        },
+    )
+}
+
+fn successive_and_with_serialized(c: &mut Criterion) {
+    successive_ops_with_serialized(
+        c,
+        "Successive And With Serialized",
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc = &*acc & &rhs;
+        },
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc &= &rhs;
+        },
+    )
+}
+
+fn successive_or_with_serialized(c: &mut Criterion) {
+    successive_ops_with_serialized(
+        c,
+        "Successive Or With Serialized",
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc = &*acc | &rhs;
+        },
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc |= &rhs;
+        },
+    )
+}
+
+fn successive_sub_with_serialized(c: &mut Criterion) {
+    successive_ops_with_serialized(
+        c,
+        "Successive Sub With Serialized",
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc = &*acc - &rhs;
+        },
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc -= &rhs;
+        },
+    )
+}
+
+fn successive_xor_with_serialized(c: &mut Criterion) {
+    successive_ops_with_serialized(
+        c,
+        "Successive Xor With Serialized",
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc = &*acc ^ &rhs;
+        },
+        |acc, b| {
+            let rhs = RoaringBitmap::deserialize_unchecked_from(b).unwrap();
+            *acc ^= &rhs;
+        },
+    )
 }
 
 // LEGACY BENCHMARKS
@@ -790,6 +967,12 @@ criterion_group!(
     successive_and,
     successive_or,
     intersection_with_serialized,
-    union_with_serialized
+    union_with_serialized,
+    difference_with_serialized,
+    symmetric_difference_with_serialized,
+    successive_and_with_serialized,
+    successive_or_with_serialized,
+    successive_sub_with_serialized,
+    successive_xor_with_serialized
 );
 criterion_main!(benches);

--- a/benchmarks/benches/lib.rs
+++ b/benchmarks/benches/lib.rs
@@ -135,7 +135,10 @@ fn pairwise_ops_with_serialized(
     let mut group = c.benchmark_group(format!("pairwise_{op_name}"));
 
     for dataset in Datasets {
-        let pairs = dataset.bitmaps.iter().tuple_windows::<(_, _)>()
+        let pairs = dataset
+            .bitmaps
+            .iter()
+            .tuple_windows::<(_, _)>()
             .map(|(a, b)| {
                 let mut buf = Vec::new();
                 b.serialize_into(&mut buf).unwrap();
@@ -668,7 +671,7 @@ fn intersection_with_serialized(c: &mut Criterion) {
         c,
         "intersection_with_serialized",
         |a, b| a.intersection_with_serialized_unchecked(Cursor::new(b)).unwrap(),
-        |a, b| a.intersection_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
+        |a, b| a.intersection_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 
@@ -677,7 +680,7 @@ fn union_with_serialized(c: &mut Criterion) {
         c,
         "union_with_serialized",
         |a, b| a.union_with_serialized_unchecked(Cursor::new(b)).unwrap(),
-        |a, b| a.union_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
+        |a, b| a.union_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 
@@ -686,7 +689,7 @@ fn difference_with_serialized(c: &mut Criterion) {
         c,
         "difference_with_serialized",
         |a, b| a.difference_with_serialized_unchecked(Cursor::new(b)).unwrap(),
-        |a, b| a.difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
+        |a, b| a.difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 
@@ -695,7 +698,7 @@ fn symmetric_difference_with_serialized(c: &mut Criterion) {
         c,
         "symmetric_difference_with_serialized",
         |a, b| a.symmetric_difference_with_serialized_unchecked(Cursor::new(b)).unwrap(),
-        |a, b| a.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap()
+        |a, b| a.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(b)).unwrap(),
     )
 }
 

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -1,10 +1,9 @@
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt};
-use core::convert::Infallible;
-use std::error::Error;
+
+use std::cmp::Ordering;
 use std::io::{self, SeekFrom};
 use std::mem;
-use std::ops::RangeInclusive;
 
 use crate::bitmap::container::Container;
 use crate::bitmap::serialization::{
@@ -41,239 +40,348 @@ impl RoaringBitmap {
     ///     rb1 & rb2,
     /// );
     /// ```
-    pub fn intersection_with_serialized_unchecked<R>(&self, other: R) -> io::Result<RoaringBitmap>
-    where
-        R: io::Read + io::Seek,
-    {
-        RoaringBitmap::intersection_with_serialized_impl::<R, _, Infallible, _, Infallible>(
-            self,
-            other,
-            |values| Ok(ArrayStore::from_vec_unchecked(values)),
-            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
-        )
-    }
-
-    fn intersection_with_serialized_impl<R, A, AErr, B, BErr>(
+    pub fn intersection_with_serialized_unchecked<R>(
         &self,
-        mut reader: R,
-        a: A,
-        b: B,
+        mut other: R,
     ) -> io::Result<RoaringBitmap>
     where
         R: io::Read + io::Seek,
-        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
-        AErr: Error + Send + Sync + 'static,
-        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
-        BErr: Error + Send + Sync + 'static,
     {
-        // First read the cookie to determine which version of the format we are reading
+        let metadata = BitmapReader::decode(&mut other)?;
+        let containers = Visitor {
+            containers: &self.containers,
+            metadata: &metadata,
+            handler: &mut BitAndHandler,
+        }
+        .visit(&mut other)?;
+        Ok(RoaringBitmap { containers })
+    }
+
+    /// Computes the union between a materialized [`RoaringBitmap`] and a serialized one.
+    ///
+    /// This is faster and more space efficient when you only need the union result.
+    /// It reduces the number of deserialized internal container and therefore
+    /// the number of allocations and copies of bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// // Let's say the rb2 bitmap is serialized
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    /// let rb2_bytes = Cursor::new(bytes);
+    ///
+    /// assert_eq!(
+    ///     rb1.union_with_serialized_unchecked(rb2_bytes).unwrap(),
+    ///     rb1 | rb2,
+    /// );
+    /// ```
+    pub fn union_with_serialized_unchecked<R>(&self, mut other: R) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+    {
+        let metadata = BitmapReader::decode(&mut other)?;
+        let containers = Visitor {
+            containers: &self.containers,
+            metadata: &metadata,
+            handler: &mut BitOrHandler,
+        }
+        .visit(&mut other)?;
+        Ok(RoaringBitmap { containers })
+    }
+}
+
+struct Visitor<'a, H> {
+    containers: &'a [Container],
+    metadata: &'a BitmapReader,
+    handler: &'a mut H,
+}
+
+impl<H> Visitor<'_, H>
+where
+    H: VisitorHandler,
+{
+    fn visit<R>(&mut self, reader: &mut R) -> io::Result<Vec<Container>>
+    where
+        R: io::Read + io::Seek,
+    {
+        let mut result = Vec::new();
+        let mut descriptions = self
+            .metadata
+            .descriptions
+            .iter()
+            .enumerate()
+            .map(|(i, &[key, len_minus_one])| MetaItem {
+                key,
+                cardinality: len_minus_one as u32 + 1,
+                is_run: self.metadata.is_run_container(i),
+                offset: self.metadata.offsets.as_ref().map(|offsets| offsets[i]),
+            })
+            .peekable();
+        let mut containers = self.containers.iter().peekable();
+
+        loop {
+            match (containers.peek(), descriptions.peek()) {
+                (Some(container), Some(item)) => match item.key.cmp(&container.key) {
+                    Ordering::Equal => {
+                        result.extend(self.consume_matched(reader, container, item)?);
+                        descriptions.next();
+                        containers.next();
+                    }
+                    Ordering::Less => {
+                        result.extend(self.consume_right(reader, item)?);
+                        descriptions.next();
+                    }
+                    Ordering::Greater => {
+                        result.extend(self.consume_left(container)?);
+                        containers.next();
+                    }
+                },
+                (None, Some(item)) => {
+                    result.extend(self.consume_right(reader, item)?);
+                    descriptions.next();
+                }
+                (Some(container), None) => {
+                    result.extend(self.consume_left(container)?);
+                    containers.next();
+                }
+                (None, None) => {
+                    return Ok(result);
+                }
+            }
+        }
+    }
+
+    fn consume_left(&mut self, container: &Container) -> io::Result<Option<Container>> {
+        self.handler.handle_left_only(container)
+    }
+
+    fn consume_right<R>(&mut self, reader: &mut R, item: &MetaItem) -> io::Result<Option<Container>>
+    where
+        R: io::Read + io::Seek,
+    {
+        if self.handler.need_handle_right_only(item.key) {
+            let container = item.load_container(reader)?;
+            self.handler.handle_right_only(container)
+        } else if item.offset.is_some() {
+            Ok(None)
+        } else {
+            item.skip(reader)?;
+            Ok(None)
+        }
+    }
+
+    fn consume_matched<R>(
+        &mut self,
+        reader: &mut R,
+        left: &Container,
+        item: &MetaItem,
+    ) -> io::Result<Option<Container>>
+    where
+        R: io::Read + io::Seek,
+    {
+        if !self.handler.need_handle_matched(left) {
+            if item.offset.is_none() {
+                item.skip(reader)?;
+            }
+            return Ok(None);
+        }
+
+        if let Some(offset) = item.offset {
+            let absolute_offset = self
+                .metadata
+                .base_offset
+                .checked_add(offset as u64)
+                .ok_or_else(|| io::Error::other("offset overflow"))?;
+            reader.seek(SeekFrom::Start(absolute_offset))?;
+        }
+        let right = item.load_container(reader)?;
+        self.handler.handel_matched(left, right)
+    }
+}
+
+struct MetaItem {
+    key: u16,
+    cardinality: u32,
+    is_run: bool,
+    offset: Option<u32>,
+}
+
+impl MetaItem {
+    fn load_container<R: io::Read>(&self, reader: &mut R) -> io::Result<Container> {
+        let store = if self.is_run {
+            let runs = reader.read_u16::<LittleEndian>()?;
+            let mut intervals = vec![[0_u16, 0]; runs as usize];
+            reader.read_u16_into::<LittleEndian>(cast_slice_mut(&mut intervals))?;
+
+            let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+            let mut store = Store::with_capacity(cardinality);
+
+            for [s, len] in intervals {
+                let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                store.insert_range(s..=end);
+            }
+            store
+        } else if self.cardinality as u64 <= ARRAY_LIMIT {
+            let mut values = vec![0; self.cardinality as usize];
+            reader.read_u16_into::<LittleEndian>(&mut values)?;
+            let array = ArrayStore::from_vec_unchecked(values);
+            Store::Array(array)
+        } else {
+            let mut values = Box::new([0; BITMAP_LENGTH]);
+            reader.read_u64_into::<LittleEndian>(values.as_mut_slice())?;
+            let bitmap = BitmapStore::from_unchecked(self.cardinality as u64, values);
+            Store::Bitmap(bitmap)
+        };
+        Ok(Container { key: self.key, store })
+    }
+
+    fn skip<R: io::Read + io::Seek>(&self, reader: &mut R) -> io::Result<()> {
+        if self.is_run {
+            let runs = reader.read_u16::<LittleEndian>()?;
+            let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
+            reader.seek_relative(runs_size as i64)?;
+        } else if self.cardinality as u64 <= ARRAY_LIMIT {
+            let array_size = mem::size_of::<u16>() * self.cardinality as usize;
+            reader.seek_relative(array_size as i64)?;
+        } else {
+            let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
+            reader.seek_relative(bitmap_size as i64)?;
+        }
+        Ok(())
+    }
+}
+
+trait VisitorHandler {
+    fn handle_left_only(&mut self, container: &Container) -> io::Result<Option<Container>>;
+
+    fn need_handle_right_only(&mut self, _key: u16) -> bool {
+        false
+    }
+
+    fn handle_right_only(&mut self, _container: Container) -> io::Result<Option<Container>> {
+        unreachable!()
+    }
+
+    fn need_handle_matched(&mut self, _container: &Container) -> bool {
+        true
+    }
+
+    fn handel_matched(
+        &mut self,
+        left: &Container,
+        right: Container,
+    ) -> io::Result<Option<Container>>;
+}
+
+struct BitAndHandler;
+
+impl VisitorHandler for BitAndHandler {
+    fn handle_left_only(&mut self, _container: &Container) -> io::Result<Option<Container>> {
+        Ok(None)
+    }
+
+    fn handel_matched(
+        &mut self,
+        left: &Container,
+        mut right: Container,
+    ) -> io::Result<Option<Container>> {
+        right &= left;
+        if right.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(right))
+        }
+    }
+}
+
+struct BitOrHandler;
+
+impl VisitorHandler for BitOrHandler {
+    fn handle_left_only(&mut self, container: &Container) -> io::Result<Option<Container>> {
+        Ok(Some(container.clone()))
+    }
+
+    fn need_handle_right_only(&mut self, _key: u16) -> bool {
+        true
+    }
+
+    fn handle_right_only(&mut self, container: Container) -> io::Result<Option<Container>> {
+        Ok(Some(container))
+    }
+
+    fn handel_matched(
+        &mut self,
+        left: &Container,
+        mut right: Container,
+    ) -> io::Result<Option<Container>> {
+        right |= left;
+        if right.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(right))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BitmapReader {
+    base_offset: u64,
+    descriptions: Box<[[u16; 2]]>,
+    offsets: Option<Box<[u32]>>,
+    run_container_bitmap: Option<Box<[u8]>>,
+}
+
+impl BitmapReader {
+    pub fn decode<R: io::Read + io::Seek>(reader: &mut R) -> io::Result<BitmapReader> {
+        let base_offset = reader.stream_position()?;
+
         let (size, has_offsets, has_run_containers) = {
             let cookie = reader.read_u32::<LittleEndian>()?;
             if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
                 (reader.read_u32::<LittleEndian>()? as usize, true, false)
             } else if (cookie as u16) == SERIAL_COOKIE {
-                let size = ((cookie >> 16) + 1) as usize;
+                let size = (cookie >> 16) as usize + 1;
                 (size, size >= NO_OFFSET_THRESHOLD, true)
             } else {
                 return Err(io::Error::other("unknown cookie value"));
             }
         };
 
-        // Read the run container bitmap if necessary
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
         let run_container_bitmap = if has_run_containers {
-            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            let mut bitmap = vec![0u8; size.div_ceil(8)].into_boxed_slice();
             reader.read_exact(&mut bitmap)?;
             Some(bitmap)
         } else {
             None
         };
 
-        if size > u16::MAX as usize + 1 {
-            return Err(io::Error::other("size is greater than supported"));
-        }
+        let mut descriptions = vec![[0; 2]; size].into_boxed_slice();
+        reader.read_u16_into::<LittleEndian>(cast_slice_mut(descriptions.as_mut()))?;
 
-        // Read the container descriptions
-        let mut descriptions = vec![[0; 2]; size];
-        reader.read_exact(cast_slice_mut(&mut descriptions))?;
-        descriptions.iter_mut().for_each(|[ref mut key, ref mut len]| {
-            *key = u16::from_le(*key);
-            *len = u16::from_le(*len);
-        });
+        let offsets = if has_offsets {
+            let mut offsets = vec![0u32; size].into_boxed_slice();
+            reader.read_u32_into::<LittleEndian>(offsets.as_mut())?;
+            Some(offsets)
+        } else {
+            None
+        };
 
-        if has_offsets {
-            let mut offsets = vec![0; size];
-            reader.read_exact(cast_slice_mut(&mut offsets))?;
-            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
-            return self.intersection_with_serialized_impl_with_offsets(
-                reader,
-                a,
-                b,
-                &descriptions,
-                &offsets,
-                run_container_bitmap.as_deref(),
-            );
-        }
-
-        // Read each container and skip the useless ones
-        let mut containers = Vec::new();
-        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
-            let container = match self.containers.binary_search_by_key(&key, |c| c.key) {
-                Ok(index) => self.containers.get(index),
-                Err(_) => None,
-            };
-            let cardinality = u64::from(len_minus_one) + 1;
-
-            // If the run container bitmap is present, check if this container is a run container
-            let is_run_container =
-                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
-
-            let store = if is_run_container {
-                let runs = reader.read_u16::<LittleEndian>()?;
-                match container {
-                    Some(_) => {
-                        let mut intervals = vec![[0, 0]; runs as usize];
-                        reader.read_exact(cast_slice_mut(&mut intervals))?;
-                        intervals.iter_mut().for_each(|[s, len]| {
-                            *s = u16::from_le(*s);
-                            *len = u16::from_le(*len);
-                        });
-
-                        let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
-                        let mut store = Store::with_capacity(cardinality);
-                        intervals.into_iter().try_for_each(
-                            |[s, len]| -> Result<(), io::ErrorKind> {
-                                let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
-                                store.insert_range(RangeInclusive::new(s, end));
-                                Ok(())
-                            },
-                        )?;
-                        store
-                    }
-                    None => {
-                        let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
-                        reader.seek(SeekFrom::Current(runs_size as i64))?;
-                        continue;
-                    }
-                }
-            } else if cardinality <= ARRAY_LIMIT {
-                match container {
-                    Some(_) => {
-                        let mut values = vec![0; cardinality as usize];
-                        reader.read_exact(cast_slice_mut(&mut values))?;
-                        values.iter_mut().for_each(|n| *n = u16::from_le(*n));
-                        let array =
-                            a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                        Store::Array(array)
-                    }
-                    None => {
-                        let array_size = mem::size_of::<u16>() * cardinality as usize;
-                        reader.seek(SeekFrom::Current(array_size as i64))?;
-                        continue;
-                    }
-                }
-            } else {
-                match container {
-                    Some(_) => {
-                        let mut values = Box::new([0; BITMAP_LENGTH]);
-                        reader.read_exact(cast_slice_mut(&mut values[..]))?;
-                        values.iter_mut().for_each(|n| *n = u64::from_le(*n));
-                        let bitmap = b(cardinality, values)
-                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                        Store::Bitmap(bitmap)
-                    }
-                    None => {
-                        let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
-                        reader.seek(SeekFrom::Current(bitmap_size as i64))?;
-                        continue;
-                    }
-                }
-            };
-
-            if let Some(container) = container {
-                let mut other_container = Container { key, store };
-                other_container &= container;
-                if !other_container.is_empty() {
-                    containers.push(other_container);
-                }
-            }
-        }
-
-        Ok(RoaringBitmap { containers })
+        Ok(BitmapReader { base_offset, descriptions, offsets, run_container_bitmap })
     }
 
-    fn intersection_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
-        &self,
-        mut reader: R,
-        a: A,
-        b: B,
-        descriptions: &[[u16; 2]],
-        offsets: &[u32],
-        run_container_bitmap: Option<&[u8]>,
-    ) -> io::Result<RoaringBitmap>
-    where
-        R: io::Read + io::Seek,
-        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
-        AErr: Error + Send + Sync + 'static,
-        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
-        BErr: Error + Send + Sync + 'static,
-    {
-        let mut containers = Vec::new();
-        for container in &self.containers {
-            let i = match descriptions.binary_search_by_key(&container.key, |[k, _]| *k) {
-                Ok(index) => index,
-                Err(_) => continue,
-            };
-
-            // Seek to the bytes of the container we want.
-            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
-
-            let [key, len_minus_one] = descriptions[i];
-            let cardinality = u64::from(len_minus_one) + 1;
-
-            // If the run container bitmap is present, check if this container is a run container
-            let is_run_container =
-                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
-
-            let store = if is_run_container {
-                let runs = reader.read_u16::<LittleEndian>().unwrap();
-                let mut intervals = vec![[0, 0]; runs as usize];
-                reader.read_exact(cast_slice_mut(&mut intervals)).unwrap();
-                intervals.iter_mut().for_each(|[s, len]| {
-                    *s = u16::from_le(*s);
-                    *len = u16::from_le(*len);
-                });
-
-                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
-                let mut store = Store::with_capacity(cardinality);
-                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
-                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
-                    store.insert_range(RangeInclusive::new(s, end));
-                    Ok(())
-                })?;
-                store
-            } else if cardinality <= ARRAY_LIMIT {
-                let mut values = vec![0; cardinality as usize];
-                reader.read_exact(cast_slice_mut(&mut values)).unwrap();
-                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
-                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                Store::Array(array)
-            } else {
-                let mut values = Box::new([0; BITMAP_LENGTH]);
-                reader.read_exact(cast_slice_mut(&mut values[..])).unwrap();
-                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
-                let bitmap = b(cardinality, values)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                Store::Bitmap(bitmap)
-            };
-
-            let mut other_container = Container { key, store };
-            other_container &= container;
-            if !other_container.is_empty() {
-                containers.push(other_container);
-            }
-        }
-
-        Ok(RoaringBitmap { containers })
+    pub fn is_run_container(&self, index: usize) -> bool {
+        self.run_container_bitmap.as_ref().is_some_and(|bm| bm[index / 8] & (1 << (index % 8)) != 0)
     }
 }
 
@@ -295,6 +403,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.intersection_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), a & b);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn union_with_serialized_eq_materialized_intersection(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            prop_assert_eq!(a.union_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), a | b);
         }
     }
 }

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -2,7 +2,6 @@ use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt};
 use core::convert::Infallible;
 
-use std::cmp::Ordering;
 use std::error::Error;
 use std::io::{self, SeekFrom};
 use std::mem;
@@ -303,285 +302,204 @@ impl RoaringBitmap {
     ///     rb1 | rb2,
     /// );
     /// ```
-    pub fn union_with_serialized_unchecked<R>(&self, mut other: R) -> io::Result<RoaringBitmap>
+    pub fn union_with_serialized_unchecked<R>(&self, other: R) -> io::Result<RoaringBitmap>
     where
         R: io::Read + io::Seek,
     {
-        let metadata = BitmapReader::decode(&mut other)?;
-        let containers = Visitor {
-            containers: &self.containers,
-            metadata: &metadata,
-            handler: &mut BitOrHandler,
-        }
-        .visit(&mut other)?;
-        Ok(RoaringBitmap { containers })
+        RoaringBitmap::union_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
     }
-}
 
-struct Visitor<'a, H> {
-    containers: &'a [Container],
-    metadata: &'a BitmapReader,
-    handler: &'a mut H,
-}
-
-impl<H> Visitor<'_, H>
-where
-    H: VisitorHandler,
-{
-    fn visit<R>(&mut self, reader: &mut R) -> io::Result<Vec<Container>>
+    fn union_with_serialized_impl<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<RoaringBitmap>
     where
         R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
     {
-        let mut result = Vec::new();
-        let mut descriptions = self
-            .metadata
-            .descriptions
-            .iter()
-            .enumerate()
-            .map(|(i, &[key, len_minus_one])| MetaItem {
-                key,
-                cardinality: len_minus_one as u32 + 1,
-                is_run: self.metadata.is_run_container(i),
-                offset: self.metadata.offsets.as_ref().map(|offsets| offsets[i]),
-            })
-            .peekable();
-        let mut containers = self.containers.iter().peekable();
-
-        loop {
-            match (containers.peek(), descriptions.peek()) {
-                (Some(container), Some(item)) => match item.key.cmp(&container.key) {
-                    Ordering::Equal => {
-                        result.extend(self.consume_matched(reader, container, item)?);
-                        descriptions.next();
-                        containers.next();
-                    }
-                    Ordering::Less => {
-                        result.extend(self.consume_right(reader, item)?);
-                        descriptions.next();
-                    }
-                    Ordering::Greater => {
-                        result.extend(self.consume_left(container)?);
-                        containers.next();
-                    }
-                },
-                (None, Some(item)) => {
-                    result.extend(self.consume_right(reader, item)?);
-                    descriptions.next();
-                }
-                (Some(container), None) => {
-                    result.extend(self.consume_left(container)?);
-                    containers.next();
-                }
-                (None, None) => {
-                    return Ok(result);
-                }
-            }
-        }
-    }
-
-    fn consume_left(&mut self, container: &Container) -> io::Result<Option<Container>> {
-        self.handler.handle_left_only(container)
-    }
-
-    fn consume_right<R>(&mut self, reader: &mut R, item: &MetaItem) -> io::Result<Option<Container>>
-    where
-        R: io::Read + io::Seek,
-    {
-        if self.handler.need_handle_right_only(item.key) {
-            let container = item.load_container(reader)?;
-            self.handler.handle_right_only(container)
-        } else if item.offset.is_some() {
-            Ok(None)
-        } else {
-            item.skip(reader)?;
-            Ok(None)
-        }
-    }
-
-    fn consume_matched<R>(
-        &mut self,
-        reader: &mut R,
-        left: &Container,
-        item: &MetaItem,
-    ) -> io::Result<Option<Container>>
-    where
-        R: io::Read + io::Seek,
-    {
-        if !self.handler.need_handle_matched(left) {
-            if item.offset.is_none() {
-                item.skip(reader)?;
-            }
-            return Ok(None);
-        }
-
-        if let Some(offset) = item.offset {
-            let absolute_offset = self
-                .metadata
-                .base_offset
-                .checked_add(offset as u64)
-                .ok_or_else(|| io::Error::other("offset overflow"))?;
-            reader.seek(SeekFrom::Start(absolute_offset))?;
-        }
-        let right = item.load_container(reader)?;
-        self.handler.handel_matched(left, right)
-    }
-}
-
-struct MetaItem {
-    key: u16,
-    cardinality: u32,
-    is_run: bool,
-    offset: Option<u32>,
-}
-
-impl MetaItem {
-    fn load_container<R: io::Read>(&self, reader: &mut R) -> io::Result<Container> {
-        let store = if self.is_run {
-            let runs = reader.read_u16::<LittleEndian>()?;
-            let mut intervals = vec![[0_u16, 0]; runs as usize];
-            reader.read_u16_into::<LittleEndian>(cast_slice_mut(&mut intervals))?;
-
-            let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
-            let mut store = Store::with_capacity(cardinality);
-
-            for [s, len] in intervals {
-                let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
-                store.insert_range(s..=end);
-            }
-            store
-        } else if self.cardinality as u64 <= ARRAY_LIMIT {
-            let mut values = vec![0; self.cardinality as usize];
-            reader.read_u16_into::<LittleEndian>(&mut values)?;
-            let array = ArrayStore::from_vec_unchecked(values);
-            Store::Array(array)
-        } else {
-            let mut values = Box::new([0; BITMAP_LENGTH]);
-            reader.read_u64_into::<LittleEndian>(values.as_mut_slice())?;
-            let bitmap = BitmapStore::from_unchecked(self.cardinality as u64, values);
-            Store::Bitmap(bitmap)
-        };
-        Ok(Container { key: self.key, store })
-    }
-
-    fn skip<R: io::Read + io::Seek>(&self, reader: &mut R) -> io::Result<()> {
-        if self.is_run {
-            let runs = reader.read_u16::<LittleEndian>()?;
-            let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
-            reader.seek_relative(runs_size as i64)?;
-        } else if self.cardinality as u64 <= ARRAY_LIMIT {
-            let array_size = mem::size_of::<u16>() * self.cardinality as usize;
-            reader.seek_relative(array_size as i64)?;
-        } else {
-            let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
-            reader.seek_relative(bitmap_size as i64)?;
-        }
-        Ok(())
-    }
-}
-
-trait VisitorHandler {
-    fn handle_left_only(&mut self, container: &Container) -> io::Result<Option<Container>>;
-
-    fn need_handle_right_only(&mut self, _key: u16) -> bool {
-        false
-    }
-
-    fn handle_right_only(&mut self, _container: Container) -> io::Result<Option<Container>> {
-        unreachable!()
-    }
-
-    fn need_handle_matched(&mut self, _container: &Container) -> bool {
-        true
-    }
-
-    fn handel_matched(
-        &mut self,
-        left: &Container,
-        right: Container,
-    ) -> io::Result<Option<Container>>;
-}
-
-struct BitOrHandler;
-
-impl VisitorHandler for BitOrHandler {
-    fn handle_left_only(&mut self, container: &Container) -> io::Result<Option<Container>> {
-        Ok(Some(container.clone()))
-    }
-
-    fn need_handle_right_only(&mut self, _key: u16) -> bool {
-        true
-    }
-
-    fn handle_right_only(&mut self, container: Container) -> io::Result<Option<Container>> {
-        Ok(Some(container))
-    }
-
-    fn handel_matched(
-        &mut self,
-        left: &Container,
-        mut right: Container,
-    ) -> io::Result<Option<Container>> {
-        right |= left;
-        if right.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(right))
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct BitmapReader {
-    base_offset: u64,
-    descriptions: Box<[[u16; 2]]>,
-    offsets: Option<Box<[u32]>>,
-    run_container_bitmap: Option<Box<[u8]>>,
-}
-
-impl BitmapReader {
-    pub fn decode<R: io::Read + io::Seek>(reader: &mut R) -> io::Result<BitmapReader> {
-        let base_offset = reader.stream_position()?;
-
         let (size, has_offsets, has_run_containers) = {
             let cookie = reader.read_u32::<LittleEndian>()?;
             if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
                 (reader.read_u32::<LittleEndian>()? as usize, true, false)
             } else if (cookie as u16) == SERIAL_COOKIE {
-                let size = (cookie >> 16) as usize + 1;
+                let size = ((cookie >> 16) + 1) as usize;
                 (size, size >= NO_OFFSET_THRESHOLD, true)
             } else {
                 return Err(io::Error::other("unknown cookie value"));
             }
         };
 
-        if size > u16::MAX as usize + 1 {
-            return Err(io::Error::other("size is greater than supported"));
-        }
-
         let run_container_bitmap = if has_run_containers {
-            let mut bitmap = vec![0u8; size.div_ceil(8)].into_boxed_slice();
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
             reader.read_exact(&mut bitmap)?;
             Some(bitmap)
         } else {
             None
         };
 
-        let mut descriptions = vec![[0; 2]; size].into_boxed_slice();
-        reader.read_u16_into::<LittleEndian>(cast_slice_mut(descriptions.as_mut()))?;
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
 
-        let offsets = if has_offsets {
-            let mut offsets = vec![0u32; size].into_boxed_slice();
-            reader.read_u32_into::<LittleEndian>(offsets.as_mut())?;
-            Some(offsets)
-        } else {
-            None
-        };
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[key, len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
 
-        Ok(BitmapReader { base_offset, descriptions, offsets, run_container_bitmap })
+        if has_offsets {
+            let mut offsets = vec![0; size];
+            reader.read_exact(cast_slice_mut(&mut offsets))?;
+            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
+            return self.union_with_serialized_impl_with_offsets(
+                reader,
+                a,
+                b,
+                &descriptions,
+                &offsets,
+                run_container_bitmap.as_deref(),
+            );
+        }
+
+        let mut containers = Vec::new();
+        let mut left_containers = self.containers.iter().peekable();
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while left_containers.peek().is_some_and(|container| container.key < key) {
+                containers.push(left_containers.next().unwrap().clone());
+            }
+
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let mut right_container = Container { key, store };
+            if left_containers.peek().is_some_and(|container| container.key == key) {
+                right_container |= left_containers.next().unwrap();
+            }
+            if !right_container.is_empty() {
+                containers.push(right_container);
+            }
+        }
+
+        containers.extend(left_containers.cloned());
+        Ok(RoaringBitmap { containers })
     }
 
-    pub fn is_run_container(&self, index: usize) -> bool {
-        self.run_container_bitmap.as_ref().is_some_and(|bm| bm[index / 8] & (1 << (index % 8)) != 0)
+    fn union_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+        descriptions: &[[u16; 2]],
+        offsets: &[u32],
+        run_container_bitmap: Option<&[u8]>,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let mut containers = Vec::new();
+        let mut left_containers = self.containers.iter().peekable();
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while left_containers.peek().is_some_and(|container| container.key < key) {
+                containers.push(left_containers.next().unwrap().clone());
+            }
+
+            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
+
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>().unwrap();
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals)).unwrap();
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values)).unwrap();
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..])).unwrap();
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let mut right_container = Container { key, store };
+            if left_containers.peek().is_some_and(|container| container.key == key) {
+                right_container |= left_containers.next().unwrap();
+            }
+            if !right_container.is_empty() {
+                containers.push(right_container);
+            }
+        }
+
+        containers.extend(left_containers.cloned());
+        Ok(RoaringBitmap { containers })
     }
 }
 

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -1,9 +1,12 @@
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt};
+use core::convert::Infallible;
 
 use std::cmp::Ordering;
+use std::error::Error;
 use std::io::{self, SeekFrom};
 use std::mem;
+use std::ops::RangeInclusive;
 
 use crate::bitmap::container::Container;
 use crate::bitmap::serialization::{
@@ -40,20 +43,238 @@ impl RoaringBitmap {
     ///     rb1 & rb2,
     /// );
     /// ```
-    pub fn intersection_with_serialized_unchecked<R>(
-        &self,
-        mut other: R,
-    ) -> io::Result<RoaringBitmap>
+    pub fn intersection_with_serialized_unchecked<R>(&self, other: R) -> io::Result<RoaringBitmap>
     where
         R: io::Read + io::Seek,
     {
-        let metadata = BitmapReader::decode(&mut other)?;
-        let containers = Visitor {
-            containers: &self.containers,
-            metadata: &metadata,
-            handler: &mut BitAndHandler,
+        RoaringBitmap::intersection_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn intersection_with_serialized_impl<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        // First read the cookie to determine which version of the format we are reading
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        // Read the run container bitmap if necessary
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
         }
-        .visit(&mut other)?;
+
+        // Read the container descriptions
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[ref mut key, ref mut len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        if has_offsets {
+            let mut offsets = vec![0; size];
+            reader.read_exact(cast_slice_mut(&mut offsets))?;
+            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
+            return self.intersection_with_serialized_impl_with_offsets(
+                reader,
+                a,
+                b,
+                &descriptions,
+                &offsets,
+                run_container_bitmap.as_deref(),
+            );
+        }
+
+        // Read each container and skip the useless ones
+        let mut containers = Vec::new();
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            let container = match self.containers.binary_search_by_key(&key, |c| c.key) {
+                Ok(index) => self.containers.get(index),
+                Err(_) => None,
+            };
+            let cardinality = u64::from(len_minus_one) + 1;
+
+            // If the run container bitmap is present, check if this container is a run container
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                match container {
+                    Some(_) => {
+                        let mut intervals = vec![[0, 0]; runs as usize];
+                        reader.read_exact(cast_slice_mut(&mut intervals))?;
+                        intervals.iter_mut().for_each(|[s, len]| {
+                            *s = u16::from_le(*s);
+                            *len = u16::from_le(*len);
+                        });
+
+                        let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                        let mut store = Store::with_capacity(cardinality);
+                        intervals.into_iter().try_for_each(
+                            |[s, len]| -> Result<(), io::ErrorKind> {
+                                let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                                store.insert_range(RangeInclusive::new(s, end));
+                                Ok(())
+                            },
+                        )?;
+                        store
+                    }
+                    None => {
+                        let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
+                        reader.seek(SeekFrom::Current(runs_size as i64))?;
+                        continue;
+                    }
+                }
+            } else if cardinality <= ARRAY_LIMIT {
+                match container {
+                    Some(_) => {
+                        let mut values = vec![0; cardinality as usize];
+                        reader.read_exact(cast_slice_mut(&mut values))?;
+                        values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                        let array =
+                            a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                        Store::Array(array)
+                    }
+                    None => {
+                        let array_size = mem::size_of::<u16>() * cardinality as usize;
+                        reader.seek(SeekFrom::Current(array_size as i64))?;
+                        continue;
+                    }
+                }
+            } else {
+                match container {
+                    Some(_) => {
+                        let mut values = Box::new([0; BITMAP_LENGTH]);
+                        reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                        values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                        let bitmap = b(cardinality, values)
+                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                        Store::Bitmap(bitmap)
+                    }
+                    None => {
+                        let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
+                        reader.seek(SeekFrom::Current(bitmap_size as i64))?;
+                        continue;
+                    }
+                }
+            };
+
+            if let Some(container) = container {
+                let mut other_container = Container { key, store };
+                other_container &= container;
+                if !other_container.is_empty() {
+                    containers.push(other_container);
+                }
+            }
+        }
+
+        Ok(RoaringBitmap { containers })
+    }
+
+    fn intersection_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+        descriptions: &[[u16; 2]],
+        offsets: &[u32],
+        run_container_bitmap: Option<&[u8]>,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let mut containers = Vec::new();
+        for container in &self.containers {
+            let i = match descriptions.binary_search_by_key(&container.key, |[k, _]| *k) {
+                Ok(index) => index,
+                Err(_) => continue,
+            };
+
+            // Seek to the bytes of the container we want.
+            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
+
+            let [key, len_minus_one] = descriptions[i];
+            let cardinality = u64::from(len_minus_one) + 1;
+
+            // If the run container bitmap is present, check if this container is a run container
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>().unwrap();
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals)).unwrap();
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values)).unwrap();
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..])).unwrap();
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let mut other_container = Container { key, store };
+            other_container &= container;
+            if !other_container.is_empty() {
+                containers.push(other_container);
+            }
+        }
+
         Ok(RoaringBitmap { containers })
     }
 
@@ -278,27 +499,6 @@ trait VisitorHandler {
         left: &Container,
         right: Container,
     ) -> io::Result<Option<Container>>;
-}
-
-struct BitAndHandler;
-
-impl VisitorHandler for BitAndHandler {
-    fn handle_left_only(&mut self, _container: &Container) -> io::Result<Option<Container>> {
-        Ok(None)
-    }
-
-    fn handel_matched(
-        &mut self,
-        left: &Container,
-        mut right: Container,
-    ) -> io::Result<Option<Container>> {
-        right &= left;
-        if right.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(right))
-        }
-    }
 }
 
 struct BitOrHandler;

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -1470,6 +1470,162 @@ impl RoaringBitmap {
         containers.extend_from_slice(&lhs[lhs_idx..]);
         Ok(RoaringBitmap { containers })
     }
+
+    /// Computes the symmetric difference between this [`RoaringBitmap`] and a
+    /// serialized one, in place.
+    ///
+    /// This is the in-place counterpart of
+    /// [`RoaringBitmap::symmetric_difference_with_serialized_unchecked`]:
+    /// containers of `self` are moved through the merge (lhs-only ones kept,
+    /// matching ones xor-ed in place reusing their allocations) and
+    /// rhs-only containers are moved in as they are read — nothing is cloned.
+    /// Prefer it when the symmetric difference result should replace `self`.
+    ///
+    /// # Errors
+    ///
+    /// If error happens, the operation stops early and `self` is left in a partially-updated state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let mut rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    ///
+    /// rb1.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(&bytes)).unwrap();
+    /// assert_eq!(rb1, (1..3).chain(4..5).collect::<RoaringBitmap>());
+    /// ```
+    pub fn symmetric_difference_assign_with_serialized_unchecked<R>(
+        &mut self,
+        other: R,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+    {
+        RoaringBitmap::symmetric_difference_assign_with_serialized_impl::<
+            R,
+            _,
+            Infallible,
+            _,
+            Infallible,
+        >(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn symmetric_difference_assign_with_serialized_impl<R, A, AErr, B, BErr>(
+        &mut self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[ref mut key, ref mut len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        if has_offsets {
+            reader.seek(SeekFrom::Current(size as i64 * 4))?;
+        }
+
+        let mut lhs_iter = mem::take(&mut self.containers).into_iter().peekable();
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while lhs_iter.peek().is_some_and(|container| container.key < key) {
+                self.containers.push(lhs_iter.next().unwrap()); // lhs-only: kept
+            }
+
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let rhs_container = Container { key, store };
+            if lhs_iter.peek().is_some_and(|container| container.key == key) {
+                let mut lhs_container = lhs_iter.next().unwrap();
+                lhs_container ^= &rhs_container;
+                if !lhs_container.is_empty() {
+                    self.containers.push(lhs_container);
+                }
+            } else if !rhs_container.is_empty() {
+                self.containers.push(rhs_container);
+            }
+        }
+
+        self.containers.extend(lhs_iter);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1574,6 +1730,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.symmetric_difference_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), &a ^ &b);
+        }
+
+        #[test]
+        fn symmetric_difference_assign_with_serialized_eq_materialized_symmetric_difference(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            let mut assigned = a.clone();
+            assigned.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap();
+            prop_assert_eq!(assigned, &a ^ &b);
         }
     }
 }

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -669,6 +669,159 @@ impl RoaringBitmap {
 
         Ok(RoaringBitmap { containers })
     }
+
+    /// Computes the symmetric difference between a materialized [`RoaringBitmap`] and a serialized one.
+    ///
+    /// This is faster and more space efficient when you only need the symmetric difference result.
+    /// It reduces the number of deserialized internal container and therefore
+    /// the number of allocations and copies of bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// // Let's say the rb2 bitmap is serialized
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    /// let rb2_bytes = Cursor::new(bytes);
+    ///
+    /// assert_eq!(
+    ///     rb1.symmetric_difference_with_serialized_unchecked(rb2_bytes).unwrap(),
+    ///     &rb1 ^ &rb2,
+    /// );
+    /// ```
+    pub fn symmetric_difference_with_serialized_unchecked<R>(
+        &self,
+        other: R,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+    {
+        RoaringBitmap::symmetric_difference_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn symmetric_difference_with_serialized_impl<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        // First read the cookie to determine which version of the format we are reading
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        // Read the run container bitmap if necessary
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
+        // Read the container descriptions
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[ref mut key, ref mut len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        // Skip the offsets if present, we don't need them for symmetric difference
+        if has_offsets {
+            reader.seek(SeekFrom::Current(size as i64 * 4))?;
+        }
+
+        // Walk rhs sequentially. Drain smaller lhs containers into result unchanged,
+        // xor when keys match, push rhs-only containers directly.
+        let mut containers = Vec::with_capacity(self.containers.len() + descriptions.len());
+        let lhs = self.containers.as_slice();
+        let mut lhs_idx = 0usize;
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while lhs_idx < lhs.len() && lhs[lhs_idx].key < key {
+                containers.push(lhs[lhs_idx].clone());
+                lhs_idx += 1;
+            }
+
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let mut container = Container { key, store };
+            if lhs_idx < lhs.len() && lhs[lhs_idx].key == key {
+                container ^= &lhs[lhs_idx];
+                lhs_idx += 1;
+            }
+            if !container.is_empty() {
+                containers.push(container);
+            }
+        }
+
+        containers.extend_from_slice(&lhs[lhs_idx..]);
+        Ok(RoaringBitmap { containers })
+    }
 }
 
 #[cfg(test)]
@@ -717,6 +870,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.difference_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), &a - &b);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn symmetric_difference_with_serialized_eq_materialized_symmetric_difference(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            prop_assert_eq!(a.symmetric_difference_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), &a ^ &b);
         }
     }
 }

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -416,6 +416,259 @@ impl RoaringBitmap {
         containers.extend(left_containers.cloned());
         Ok(RoaringBitmap { containers })
     }
+
+    /// Computes the difference between a materialized [`RoaringBitmap`] and a serialized one.
+    ///
+    /// This is faster and more space efficient when you only need the difference result.
+    /// It reduces the number of deserialized internal container and therefore
+    /// the number of allocations and copies of bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// // Let's say the rb2 bitmap is serialized
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    /// let rb2_bytes = Cursor::new(bytes);
+    ///
+    /// assert_eq!(
+    ///     rb1.difference_with_serialized_unchecked(rb2_bytes).unwrap(),
+    ///     &rb1 - &rb2,
+    /// );
+    /// ```
+    pub fn difference_with_serialized_unchecked<R>(&self, other: R) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+    {
+        RoaringBitmap::difference_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn difference_with_serialized_impl<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        // First read the cookie to determine which version of the format we are reading
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        // Read the run container bitmap if necessary
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
+        // Read the container descriptions
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[ref mut key, ref mut len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        if has_offsets {
+            let mut offsets = vec![0; size];
+            reader.read_exact(cast_slice_mut(&mut offsets))?;
+            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
+            return self.difference_with_serialized_impl_with_offsets(
+                reader,
+                a,
+                b,
+                &descriptions,
+                &offsets,
+                run_container_bitmap.as_deref(),
+            );
+        }
+
+        // Walk rhs in order. Drain smaller lhs containers into result unchanged,
+        // subtract when keys match, skip rhs bytes when lhs has no matching key.
+        let mut containers = Vec::with_capacity(self.containers.len());
+        let lhs = self.containers.as_slice();
+        let mut lhs_idx = 0usize;
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while lhs_idx < lhs.len() && lhs[lhs_idx].key < key {
+                containers.push(lhs[lhs_idx].clone());
+                lhs_idx += 1;
+            }
+
+            let lhs_matches = lhs_idx < lhs.len() && lhs[lhs_idx].key == key;
+            let cardinality = u64::from(len_minus_one) + 1;
+
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            if !lhs_matches {
+                if is_run_container {
+                    let runs = reader.read_u16::<LittleEndian>()?;
+                    let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
+                    reader.seek(SeekFrom::Current(runs_size as i64))?;
+                } else if cardinality <= ARRAY_LIMIT {
+                    let array_size = mem::size_of::<u16>() * cardinality as usize;
+                    reader.seek(SeekFrom::Current(array_size as i64))?;
+                } else {
+                    let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
+                    reader.seek(SeekFrom::Current(bitmap_size as i64))?;
+                }
+                continue;
+            }
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let other_container = Container { key, store };
+            let mut lhs_container = lhs[lhs_idx].clone();
+            lhs_container -= &other_container;
+            if !lhs_container.is_empty() {
+                containers.push(lhs_container);
+            }
+            lhs_idx += 1;
+        }
+
+        containers.extend_from_slice(&lhs[lhs_idx..]);
+        Ok(RoaringBitmap { containers })
+    }
+
+    fn difference_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
+        &self,
+        mut reader: R,
+        a: A,
+        b: B,
+        descriptions: &[[u16; 2]],
+        offsets: &[u32],
+        run_container_bitmap: Option<&[u8]>,
+    ) -> io::Result<RoaringBitmap>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let mut containers = Vec::with_capacity(self.containers.len());
+        for container in &self.containers {
+            let i = match descriptions.binary_search_by_key(&container.key, |[k, _]| *k) {
+                Ok(index) => index,
+                Err(_) => {
+                    containers.push(container.clone());
+                    continue;
+                }
+            };
+
+            // Seek to the bytes of the container we want.
+            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
+
+            let [key, len_minus_one] = descriptions[i];
+            let cardinality = u64::from(len_minus_one) + 1;
+
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let other_container = Container { key, store };
+            let mut lhs_container = container.clone();
+            lhs_container -= &other_container;
+            if !lhs_container.is_empty() {
+                containers.push(lhs_container);
+            }
+        }
+
+        Ok(RoaringBitmap { containers })
+    }
 }
 
 #[cfg(test)]
@@ -450,6 +703,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.union_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), a | b);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn difference_with_serialized_eq_materialized_difference(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            prop_assert_eq!(a.difference_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), &a - &b);
         }
     }
 }

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -668,6 +668,146 @@ impl RoaringBitmap {
         Ok(RoaringBitmap { containers })
     }
 
+    /// Computes the union between this [`RoaringBitmap`] and a serialized one,
+    /// in place.
+    ///
+    /// This is the in-place counterpart of
+    /// [`RoaringBitmap::union_with_serialized_unchecked`]: containers already
+    /// present in `self` are merged in place (reusing their allocations) and
+    /// containers only present in `other` are moved into `self`, so no result
+    /// bitmap is allocated. Prefer it when the union result should replace
+    /// `self`.
+    ///
+    /// # Errors
+    ///
+    /// If error happens, the operation stops early and `self` is left in a partially-updated state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let mut rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    ///
+    /// rb1.union_assign_with_serialized_unchecked(Cursor::new(&bytes)).unwrap();
+    /// assert_eq!(rb1, (1..5).collect::<RoaringBitmap>());
+    /// ```
+    pub fn union_assign_with_serialized_unchecked<R>(&mut self, other: R) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+    {
+        RoaringBitmap::union_assign_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn union_assign_with_serialized_impl<R, A, AErr, B, BErr>(
+        &mut self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[key, len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        if has_offsets {
+            reader.seek(SeekFrom::Current(size as i64 * 4))?;
+        }
+
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let rhs_container = Container { key, store };
+            match self.containers.binary_search_by_key(&key, |c| c.key) {
+                Ok(loc) => {
+                    self.containers[loc] |= rhs_container;
+                }
+                Err(loc) => {
+                    self.containers.insert(loc, rhs_container);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Computes the difference between a materialized [`RoaringBitmap`] and a serialized one.
     ///
     /// This is faster and more space efficient when you only need the difference result.
@@ -1121,6 +1261,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.union_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), a | b);
+        }
+
+        #[test]
+        fn union_assign_with_serialized_eq_materialized_union(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            let mut assigned = a.clone();
+            assigned.union_assign_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap();
+            prop_assert_eq!(assigned, a | b);
         }
     }
 

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -526,7 +526,7 @@ mod test {
 
     proptest! {
         #[test]
-        fn union_with_serialized_eq_materialized_intersection(
+        fn union_with_serialized_eq_materialized_union(
             a in RoaringBitmap::arbitrary(),
             b in RoaringBitmap::arbitrary()
         ) {

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -276,6 +276,257 @@ impl RoaringBitmap {
         Ok(RoaringBitmap { containers })
     }
 
+    /// Computes the intersection between this [`RoaringBitmap`] and a serialized one,
+    /// in place.
+    ///
+    /// This is the in-place counterpart of
+    /// [`RoaringBitmap::intersection_with_serialized_unchecked`]: containers of `self` are merged
+    /// in place (reusing their allocations) and containers absent from `other` are removed,
+    /// so no result bitmap is allocated. Prefer it when the intersection result should replace
+    /// `self`.
+    ///
+    /// # Errors
+    ///
+    /// If error happens, the operation stops early and `self` is left in a partially-updated state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let mut rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    ///
+    /// rb1.intersection_assign_with_serialized_unchecked(Cursor::new(&bytes)).unwrap();
+    /// assert_eq!(rb1, (3..4).collect::<RoaringBitmap>());
+    /// ```
+    pub fn intersection_assign_with_serialized_unchecked<R>(&mut self, other: R) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+    {
+        RoaringBitmap::intersection_assign_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn intersection_assign_with_serialized_impl<R, A, AErr, B, BErr>(
+        &mut self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[key, len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        if has_offsets {
+            let mut offsets = vec![0; size];
+            reader.read_exact(cast_slice_mut(&mut offsets))?;
+            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
+            return self.intersection_assign_with_serialized_impl_with_offsets(
+                reader,
+                a,
+                b,
+                &descriptions,
+                &offsets,
+                run_container_bitmap.as_deref(),
+            );
+        }
+
+        // No offsets table
+        let mut write = 0usize;
+        let mut read = 0usize;
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while read < self.containers.len() && self.containers[read].key < key {
+                read += 1; // lhs-only
+            }
+
+            let lhs_matches = read < self.containers.len() && self.containers[read].key == key;
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            if !lhs_matches {
+                if is_run_container {
+                    let runs = reader.read_u16::<LittleEndian>()?;
+                    let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
+                    reader.seek(SeekFrom::Current(runs_size as i64))?;
+                } else if cardinality <= ARRAY_LIMIT {
+                    let array_size = mem::size_of::<u16>() * cardinality as usize;
+                    reader.seek(SeekFrom::Current(array_size as i64))?;
+                } else {
+                    let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
+                    reader.seek(SeekFrom::Current(bitmap_size as i64))?;
+                }
+                continue;
+            }
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let rhs_container = Container { key, store };
+            let k = self.containers[read].key;
+            let mut lhs_container = mem::replace(&mut self.containers[read], Container::new(k));
+            lhs_container &= rhs_container;
+            if !lhs_container.is_empty() {
+                self.containers[write] = lhs_container;
+                write += 1;
+            }
+            read += 1;
+        }
+
+        self.containers.truncate(write);
+        Ok(())
+    }
+
+    fn intersection_assign_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
+        &mut self,
+        mut reader: R,
+        a: A,
+        b: B,
+        descriptions: &[[u16; 2]],
+        offsets: &[u32],
+        run_container_bitmap: Option<&[u8]>,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let mut write = 0usize;
+        for read in 0..self.containers.len() {
+            let i = match descriptions.binary_search_by_key(&self.containers[read].key, |[k, _]| *k)
+            {
+                Ok(index) => index,
+                Err(_) => continue, // not part of the intersection, dropped
+            };
+
+            // Skip rhs using offsets table.
+            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
+
+            let [key, len_minus_one] = descriptions[i];
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let rhs_container = Container { key, store };
+            let placeholder = Container::new(self.containers[read].key);
+            let mut lhs_container = mem::replace(&mut self.containers[read], placeholder);
+            lhs_container &= rhs_container;
+            if !lhs_container.is_empty() {
+                self.containers[write] = lhs_container;
+                write += 1;
+            }
+        }
+
+        self.containers.truncate(write);
+        Ok(())
+    }
+
     /// Computes the union between a materialized [`RoaringBitmap`] and a serialized one.
     ///
     /// This is faster and more space efficient when you only need the union result.
@@ -842,6 +1093,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.intersection_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), a & b);
+        }
+
+        #[test]
+        fn intersection_assign_with_serialized_eq_materialized_intersection(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            let mut assigned = a.clone();
+            assigned.intersection_assign_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap();
+            prop_assert_eq!(assigned, a & b);
         }
     }
 

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -1,7 +1,6 @@
 use bytemuck::cast_slice_mut;
 use byteorder::{LittleEndian, ReadBytesExt};
 use core::convert::Infallible;
-
 use std::error::Error;
 use std::io::{self, SeekFrom};
 use std::mem;
@@ -359,17 +358,7 @@ impl RoaringBitmap {
         });
 
         if has_offsets {
-            let mut offsets = vec![0; size];
-            reader.read_exact(cast_slice_mut(&mut offsets))?;
-            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
-            return self.union_with_serialized_impl_with_offsets(
-                reader,
-                a,
-                b,
-                &descriptions,
-                &offsets,
-                run_container_bitmap.as_deref(),
-            );
+            reader.seek(SeekFrom::Current(size as i64 * 4))?;
         }
 
         let mut containers = Vec::new();
@@ -409,80 +398,6 @@ impl RoaringBitmap {
             } else {
                 let mut values = Box::new([0; BITMAP_LENGTH]);
                 reader.read_exact(cast_slice_mut(&mut values[..]))?;
-                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
-                let bitmap = b(cardinality, values)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                Store::Bitmap(bitmap)
-            };
-
-            let mut right_container = Container { key, store };
-            if left_containers.peek().is_some_and(|container| container.key == key) {
-                right_container |= left_containers.next().unwrap();
-            }
-            if !right_container.is_empty() {
-                containers.push(right_container);
-            }
-        }
-
-        containers.extend(left_containers.cloned());
-        Ok(RoaringBitmap { containers })
-    }
-
-    fn union_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
-        &self,
-        mut reader: R,
-        a: A,
-        b: B,
-        descriptions: &[[u16; 2]],
-        offsets: &[u32],
-        run_container_bitmap: Option<&[u8]>,
-    ) -> io::Result<RoaringBitmap>
-    where
-        R: io::Read + io::Seek,
-        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
-        AErr: Error + Send + Sync + 'static,
-        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
-        BErr: Error + Send + Sync + 'static,
-    {
-        let mut containers = Vec::new();
-        let mut left_containers = self.containers.iter().peekable();
-        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
-            while left_containers.peek().is_some_and(|container| container.key < key) {
-                containers.push(left_containers.next().unwrap().clone());
-            }
-
-            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
-
-            let cardinality = u64::from(len_minus_one) + 1;
-            let is_run_container =
-                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
-
-            let store = if is_run_container {
-                let runs = reader.read_u16::<LittleEndian>().unwrap();
-                let mut intervals = vec![[0, 0]; runs as usize];
-                reader.read_exact(cast_slice_mut(&mut intervals)).unwrap();
-                intervals.iter_mut().for_each(|[s, len]| {
-                    *s = u16::from_le(*s);
-                    *len = u16::from_le(*len);
-                });
-
-                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
-                let mut store = Store::with_capacity(cardinality);
-                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
-                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
-                    store.insert_range(RangeInclusive::new(s, end));
-                    Ok(())
-                })?;
-                store
-            } else if cardinality <= ARRAY_LIMIT {
-                let mut values = vec![0; cardinality as usize];
-                reader.read_exact(cast_slice_mut(&mut values)).unwrap();
-                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
-                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                Store::Array(array)
-            } else {
-                let mut values = Box::new([0; BITMAP_LENGTH]);
-                reader.read_exact(cast_slice_mut(&mut values[..])).unwrap();
                 values.iter_mut().for_each(|n| *n = u64::from_le(*n));
                 let bitmap = b(cardinality, values)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -1061,6 +1061,263 @@ impl RoaringBitmap {
         Ok(RoaringBitmap { containers })
     }
 
+    /// Computes the difference between a serialized [`RoaringBitmap`] and this one,
+    /// in place: `self` keeps the values absent from `other`.
+    ///
+    /// This is the in-place counterpart of
+    /// [`RoaringBitmap::difference_with_serialized_unchecked`]: containers of
+    /// `self` are subtracted in place (reusing their allocations) and moved
+    /// within the same Vec — no result bitmap is allocated and nothing is
+    /// cloned. Prefer it when the difference result should replace `self`.
+    ///
+    /// # Errors
+    ///
+    /// If error happens, the operation stops early and `self` is left in a partially-updated state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringBitmap;
+    /// use std::io::Cursor;
+    ///
+    /// let mut rb1: RoaringBitmap = (1..4).collect();
+    /// let rb2: RoaringBitmap = (3..5).collect();
+    ///
+    /// let mut bytes = Vec::new();
+    /// rb2.serialize_into(&mut bytes).unwrap();
+    ///
+    /// rb1.difference_assign_with_serialized_unchecked(Cursor::new(&bytes)).unwrap();
+    /// assert_eq!(rb1, (1..3).collect::<RoaringBitmap>());
+    /// ```
+    pub fn difference_assign_with_serialized_unchecked<R>(&mut self, other: R) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+    {
+        RoaringBitmap::difference_assign_with_serialized_impl::<R, _, Infallible, _, Infallible>(
+            self,
+            other,
+            |values| Ok(ArrayStore::from_vec_unchecked(values)),
+            |len, values| Ok(BitmapStore::from_unchecked(len, values)),
+        )
+    }
+
+    fn difference_assign_with_serialized_impl<R, A, AErr, B, BErr>(
+        &mut self,
+        mut reader: R,
+        a: A,
+        b: B,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let (size, has_offsets, has_run_containers) = {
+            let cookie = reader.read_u32::<LittleEndian>()?;
+            if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
+                (reader.read_u32::<LittleEndian>()? as usize, true, false)
+            } else if (cookie as u16) == SERIAL_COOKIE {
+                let size = ((cookie >> 16) + 1) as usize;
+                (size, size >= NO_OFFSET_THRESHOLD, true)
+            } else {
+                return Err(io::Error::other("unknown cookie value"));
+            }
+        };
+
+        let run_container_bitmap = if has_run_containers {
+            let mut bitmap = vec![0u8; size.div_ceil(8)];
+            reader.read_exact(&mut bitmap)?;
+            Some(bitmap)
+        } else {
+            None
+        };
+
+        if size > u16::MAX as usize + 1 {
+            return Err(io::Error::other("size is greater than supported"));
+        }
+
+        let mut descriptions = vec![[0; 2]; size];
+        reader.read_exact(cast_slice_mut(&mut descriptions))?;
+        descriptions.iter_mut().for_each(|[key, len]| {
+            *key = u16::from_le(*key);
+            *len = u16::from_le(*len);
+        });
+
+        if has_offsets {
+            let mut offsets = vec![0; size];
+            reader.read_exact(cast_slice_mut(&mut offsets))?;
+            offsets.iter_mut().for_each(|offset| *offset = u32::from_le(*offset));
+            return self.difference_assign_with_serialized_impl_with_offsets(
+                reader,
+                a,
+                b,
+                &descriptions,
+                &offsets,
+                run_container_bitmap.as_deref(),
+            );
+        }
+
+        // No offsets table
+        let mut write = 0usize;
+        let mut read = 0usize;
+        for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
+            while read < self.containers.len() && self.containers[read].key < key {
+                self.containers.swap(write, read); // lhs-only: kept
+                write += 1;
+                read += 1;
+            }
+
+            let lhs_matches = read < self.containers.len() && self.containers[read].key == key;
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            if !lhs_matches {
+                if is_run_container {
+                    let runs = reader.read_u16::<LittleEndian>()?;
+                    let runs_size = mem::size_of::<u16>() * 2 * runs as usize;
+                    reader.seek(SeekFrom::Current(runs_size as i64))?;
+                } else if cardinality <= ARRAY_LIMIT {
+                    let array_size = mem::size_of::<u16>() * cardinality as usize;
+                    reader.seek(SeekFrom::Current(array_size as i64))?;
+                } else {
+                    let bitmap_size = mem::size_of::<u64>() * BITMAP_LENGTH;
+                    reader.seek(SeekFrom::Current(bitmap_size as i64))?;
+                }
+                continue;
+            }
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let other_container = Container { key, store };
+            self.containers.swap(write, read); // lhs to the write slot
+            self.containers[write] -= &other_container;
+            if !self.containers[write].is_empty() {
+                write += 1;
+            }
+            read += 1;
+        }
+
+        for idx in read..self.containers.len() {
+            self.containers.swap(write, idx);
+            write += 1;
+        }
+        self.containers.truncate(write);
+        Ok(())
+    }
+
+    fn difference_assign_with_serialized_impl_with_offsets<R, A, AErr, B, BErr>(
+        &mut self,
+        mut reader: R,
+        a: A,
+        b: B,
+        descriptions: &[[u16; 2]],
+        offsets: &[u32],
+        run_container_bitmap: Option<&[u8]>,
+    ) -> io::Result<()>
+    where
+        R: io::Read + io::Seek,
+        A: Fn(Vec<u16>) -> Result<ArrayStore, AErr>,
+        AErr: Error + Send + Sync + 'static,
+        B: Fn(u64, Box<[u64; 1024]>) -> Result<BitmapStore, BErr>,
+        BErr: Error + Send + Sync + 'static,
+    {
+        let mut write = 0usize;
+        for read in 0..self.containers.len() {
+            let i = match descriptions.binary_search_by_key(&self.containers[read].key, |[k, _]| *k)
+            {
+                Ok(index) => index,
+                Err(_) => {
+                    self.containers.swap(write, read); // lhs-only: kept
+                    write += 1;
+                    continue;
+                }
+            };
+
+            // Skip rhs using offsets table.
+            reader.seek(SeekFrom::Start(offsets[i] as u64))?;
+
+            let [key, len_minus_one] = descriptions[i];
+            let cardinality = u64::from(len_minus_one) + 1;
+            let is_run_container =
+                run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
+
+            let store = if is_run_container {
+                let runs = reader.read_u16::<LittleEndian>()?;
+                let mut intervals = vec![[0, 0]; runs as usize];
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
+                intervals.iter_mut().for_each(|[s, len]| {
+                    *s = u16::from_le(*s);
+                    *len = u16::from_le(*len);
+                });
+
+                let cardinality = intervals.iter().map(|[_, len]| *len as usize).sum();
+                let mut store = Store::with_capacity(cardinality);
+                intervals.into_iter().try_for_each(|[s, len]| -> Result<(), io::ErrorKind> {
+                    let end = s.checked_add(len).ok_or(io::ErrorKind::InvalidData)?;
+                    store.insert_range(RangeInclusive::new(s, end));
+                    Ok(())
+                })?;
+                store
+            } else if cardinality <= ARRAY_LIMIT {
+                let mut values = vec![0; cardinality as usize];
+                reader.read_exact(cast_slice_mut(&mut values))?;
+                values.iter_mut().for_each(|n| *n = u16::from_le(*n));
+                let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Array(array)
+            } else {
+                let mut values = Box::new([0; BITMAP_LENGTH]);
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
+                values.iter_mut().for_each(|n| *n = u64::from_le(*n));
+                let bitmap = b(cardinality, values)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Store::Bitmap(bitmap)
+            };
+
+            let other_container = Container { key, store };
+            self.containers.swap(write, read); // lhs to the write slot
+            self.containers[write] -= &other_container;
+            if !self.containers[write].is_empty() {
+                write += 1;
+            }
+        }
+
+        self.containers.truncate(write);
+        Ok(())
+    }
+
     /// Computes the symmetric difference between a materialized [`RoaringBitmap`] and a serialized one.
     ///
     /// This is faster and more space efficient when you only need the symmetric difference result.
@@ -1289,6 +1546,20 @@ mod test {
             let serialized_bytes_b = &serialized_bytes_b[..];
 
             prop_assert_eq!(a.difference_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap(), &a - &b);
+        }
+
+        #[test]
+        fn difference_assign_with_serialized_eq_materialized_difference(
+            a in RoaringBitmap::arbitrary(),
+            b in RoaringBitmap::arbitrary()
+        ) {
+            let mut serialized_bytes_b = Vec::new();
+            b.serialize_into(&mut serialized_bytes_b).unwrap();
+            let serialized_bytes_b = &serialized_bytes_b[..];
+
+            let mut assigned = a.clone();
+            assigned.difference_assign_with_serialized_unchecked(Cursor::new(serialized_bytes_b)).unwrap();
+            prop_assert_eq!(assigned, &a - &b);
         }
     }
 

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -361,7 +361,7 @@ impl RoaringBitmap {
             reader.seek(SeekFrom::Current(size as i64 * 4))?;
         }
 
-        let mut containers = Vec::new();
+        let mut containers = Vec::with_capacity(self.containers.len() + descriptions.len());
         let mut left_containers = self.containers.iter().peekable();
         for (i, &[key, len_minus_one]) in descriptions.iter().enumerate() {
             while left_containers.peek().is_some_and(|container| container.key < key) {

--- a/roaring/src/bitmap/ops_with_serialized.rs
+++ b/roaring/src/bitmap/ops_with_serialized.rs
@@ -236,9 +236,9 @@ impl RoaringBitmap {
                 run_container_bitmap.as_ref().is_some_and(|bm| bm[i / 8] & (1 << (i % 8)) != 0);
 
             let store = if is_run_container {
-                let runs = reader.read_u16::<LittleEndian>().unwrap();
+                let runs = reader.read_u16::<LittleEndian>()?;
                 let mut intervals = vec![[0, 0]; runs as usize];
-                reader.read_exact(cast_slice_mut(&mut intervals)).unwrap();
+                reader.read_exact(cast_slice_mut(&mut intervals))?;
                 intervals.iter_mut().for_each(|[s, len]| {
                     *s = u16::from_le(*s);
                     *len = u16::from_le(*len);
@@ -254,13 +254,13 @@ impl RoaringBitmap {
                 store
             } else if cardinality <= ARRAY_LIMIT {
                 let mut values = vec![0; cardinality as usize];
-                reader.read_exact(cast_slice_mut(&mut values)).unwrap();
+                reader.read_exact(cast_slice_mut(&mut values))?;
                 values.iter_mut().for_each(|n| *n = u16::from_le(*n));
                 let array = a(values).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                 Store::Array(array)
             } else {
                 let mut values = Box::new([0; BITMAP_LENGTH]);
-                reader.read_exact(cast_slice_mut(&mut values[..])).unwrap();
+                reader.read_exact(cast_slice_mut(&mut values[..]))?;
                 values.iter_mut().for_each(|n| *n = u64::from_le(*n));
                 let bitmap = b(cardinality, values)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;

--- a/roaring/src/treemap/entry.rs
+++ b/roaring/src/treemap/entry.rs
@@ -1,0 +1,202 @@
+use alloc::collections::btree_map;
+
+use crate::{RoaringBitmap, RoaringTreemap};
+
+/// A view into a single partition of a [`RoaringTreemap`], obtained from
+/// [`RoaringTreemap::bitmap_entry`].
+///
+/// This is the entry-point style access for per-partition in-place
+/// mutation: it lets callers locate, mutate, insert, or take out the
+/// [`RoaringBitmap`] of one partition without rebuilding the treemap
+/// around it.
+pub enum BitmapEntry<'a> {
+    /// The partition is absent.
+    Vacant(VacantBitmapEntry<'a>),
+    /// The partition exists.
+    Occupied(OccupiedBitmapEntry<'a>),
+}
+
+/// A vacant partition view, obtained from [`RoaringTreemap::bitmap_entry`].
+///
+/// Use [`VacantBitmapEntry::insert`] to create that partition.
+pub struct VacantBitmapEntry<'a> {
+    inner: btree_map::VacantEntry<'a, u32, RoaringBitmap>,
+}
+
+/// An occupied partition view, obtained from [`RoaringTreemap::bitmap_entry`].
+///
+/// Use [`OccupiedBitmapEntry::get_mut`] to borrow its bitmap mutably and
+/// [`OccupiedBitmapEntry::remove`] to take it out.
+pub struct OccupiedBitmapEntry<'a> {
+    inner: btree_map::OccupiedEntry<'a, u32, RoaringBitmap>,
+}
+
+impl<'a> VacantBitmapEntry<'a> {
+    /// Inserts a bitmap into the vacant partition and returns a mutable reference to it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::{RoaringBitmap, RoaringTreemap};
+    /// use roaring::treemap::BitmapEntry;
+    ///
+    /// let mut treemap = RoaringTreemap::new();
+    /// match treemap.bitmap_entry(3) {
+    ///     BitmapEntry::Vacant(entry) => {
+    ///         let bitmap = entry.insert(RoaringBitmap::from([1]));
+    ///         bitmap.insert(2);
+    ///     }
+    ///     BitmapEntry::Occupied(_) => unreachable!(),
+    /// }
+    /// assert_eq!(treemap.len(), 2);
+    /// ```
+    pub fn insert(self, bitmap: RoaringBitmap) -> &'a mut RoaringBitmap {
+        self.inner.insert(bitmap)
+    }
+}
+
+impl OccupiedBitmapEntry<'_> {
+    /// Returns a mutable reference to the partition's bitmap.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringTreemap;
+    /// use roaring::treemap::BitmapEntry;
+    ///
+    /// let mut treemap = RoaringTreemap::new();
+    /// treemap.insert(1);
+    /// if let BitmapEntry::Occupied(mut entry) = treemap.bitmap_entry(0) {
+    ///     entry.get_mut().insert(2);
+    /// }
+    /// assert_eq!(treemap.len(), 2);
+    /// ```
+    pub fn get_mut(&mut self) -> &mut RoaringBitmap {
+        self.inner.get_mut()
+    }
+
+    /// Takes the partition's bitmap out of the treemap, removing the partition.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::RoaringTreemap;
+    /// use roaring::treemap::BitmapEntry;
+    ///
+    /// let mut treemap = RoaringTreemap::new();
+    /// treemap.insert(1);
+    /// if let BitmapEntry::Occupied(entry) = treemap.bitmap_entry(0) {
+    ///     assert_eq!(entry.remove().len(), 1);
+    /// }
+    /// assert!(treemap.is_empty());
+    /// ```
+    pub fn remove(self) -> RoaringBitmap {
+        self.inner.remove()
+    }
+}
+
+impl RoaringTreemap {
+    /// Returns a view into the partition with the given prefix (the 32 most significant bits).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use roaring::{RoaringBitmap, RoaringTreemap};
+    /// use roaring::treemap::BitmapEntry;
+    ///
+    /// let mut treemap = RoaringTreemap::new();
+    ///
+    /// // Vacant: insert a new partition.
+    /// match treemap.bitmap_entry(0) {
+    ///     BitmapEntry::Vacant(entry) => { entry.insert(RoaringBitmap::from([1])); }
+    ///     BitmapEntry::Occupied(_) => unreachable!(),
+    /// }
+    ///
+    /// // Occupied: mutate the partition in place.
+    /// match treemap.bitmap_entry(0) {
+    ///     BitmapEntry::Occupied(mut entry) => { entry.get_mut().insert(2); }
+    ///     BitmapEntry::Vacant(_) => unreachable!(),
+    /// }
+    /// assert_eq!(treemap.len(), 2);
+    /// ```
+    pub fn bitmap_entry(&mut self, prefix: u32) -> BitmapEntry<'_> {
+        match self.map.entry(prefix) {
+            btree_map::Entry::Vacant(inner) => BitmapEntry::Vacant(VacantBitmapEntry { inner }),
+            btree_map::Entry::Occupied(inner) => {
+                BitmapEntry::Occupied(OccupiedBitmapEntry { inner })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{RoaringBitmap, RoaringTreemap};
+    use proptest::prelude::*;
+
+    use super::BitmapEntry;
+
+    proptest! {
+        #[test]
+        fn occupied_entry_remove_and_insert(
+            treemap in RoaringTreemap::arbitrary(),
+        ) {
+            let mut treemap = treemap;
+            let Some(prefix) = treemap.iter().next().map(|v| (v >> 32) as u32) else {
+                // empty treemap: a lookup is vacant
+                return Ok(());
+            };
+
+            // Occupied: take the bitmap out, then put it back.
+            let expected = treemap.clone();
+            let bitmap = match treemap.bitmap_entry(prefix) {
+                BitmapEntry::Occupied(entry) => entry.remove(),
+                BitmapEntry::Vacant(_) => unreachable!("prefix exists"),
+            };
+            prop_assert!(matches!(treemap.bitmap_entry(prefix), BitmapEntry::Vacant(_)));
+
+            match treemap.bitmap_entry(prefix) {
+                BitmapEntry::Vacant(entry) => {
+                    entry.insert(bitmap);
+                }
+                BitmapEntry::Occupied(_) => unreachable!("prefix was removed"),
+            }
+            prop_assert_eq!(treemap, expected);
+        }
+
+        #[test]
+        fn vacant_entry_insert(
+            treemap in RoaringTreemap::arbitrary(),
+            prefix in any::<u32>(),
+            bitmap in RoaringBitmap::arbitrary(),
+        ) {
+            let mut treemap = treemap;
+            // Start from a guaranteed-vacant prefix (drop it if present).
+            if let BitmapEntry::Occupied(entry) = treemap.bitmap_entry(prefix) {
+                entry.remove();
+            }
+
+            // A vacant lookup inserts nothing.
+            let before = treemap.clone();
+            match treemap.bitmap_entry(prefix) {
+                BitmapEntry::Vacant(_) => {}
+                BitmapEntry::Occupied(_) => unreachable!("prefix was removed"),
+            }
+            prop_assert_eq!(&treemap, &before);
+
+            // Inserting through the vacant entry makes it occupied with that bitmap.
+            match treemap.bitmap_entry(prefix) {
+                BitmapEntry::Vacant(entry) => {
+                    entry.insert(bitmap.clone());
+                }
+                BitmapEntry::Occupied(_) => unreachable!("prefix was removed"),
+            }
+            match treemap.bitmap_entry(prefix) {
+                BitmapEntry::Occupied(mut entry) => {
+                    prop_assert_eq!(&*entry.get_mut(), &bitmap);
+                }
+                BitmapEntry::Vacant(_) => unreachable!("prefix was inserted"),
+            }
+        }
+    }
+}

--- a/roaring/src/treemap/mod.rs
+++ b/roaring/src/treemap/mod.rs
@@ -9,6 +9,7 @@ mod util;
 // the docs
 mod arbitrary;
 mod cmp;
+mod entry;
 mod inherent;
 mod iter;
 mod ops;
@@ -17,6 +18,7 @@ mod serde;
 #[cfg(feature = "std")]
 mod serialization;
 
+pub use self::entry::{BitmapEntry, OccupiedBitmapEntry, VacantBitmapEntry};
 pub use self::iter::{BitmapIter, IntoIter, Iter};
 
 /// A compressed bitmap with u64 values.


### PR DESCRIPTION
This is a follow-up to #343.

This PR completes the `*_with_serialized_unchecked` family and adds:

- **Borrowing ops**:
  - `intersection_with_serialized_unchecked` (existing)
  - `union_with_serialized_unchecked` (from #343)
  - `difference_with_serialized_unchecked`
  - `symmetric_difference_with_serialized_unchecked`
- **In-place ops** for successive accumulation senarios:
  - `intersection_assign_with_serialized_unchecked`
  - `union_assign_with_serialized_unchecked`
  - `difference_assign_with_serialized_unchecked`
  - `symmetric_difference_assign_with_serialized_unchecked`
- **Treemap access** to allow user maintains treemap inplace instead of rebuild: 
  - `RoaringTreemap::bitmap_entry(&mut self, prefix: u32) -> BitmapEntry` 
  - `BitmapEntry::{Vacant, Occupied}` with methods (`insert` / `get_mut` / `remove`)

## Design notes

- The borrowing ops walk the rhs stream once and merge as they read:
  intersection/difference use the offsets table to seek straight to
  lhs-matching containers and never read rhs-only bytes;
  union/symmetric_difference read every rhs container sequentially.

- The assign implementations mirror the `Bit{And,Or,Sub,Xor}Assign` impls:
  intersection/difference compact the containers in place;
  union merges via `binary_search` + `Vec::insert`;
  symmetric_difference rebuilds via `mem::take` + merge.
  
- Like the existing borrowing variants, these are `_unchecked`: the input
  is trusted to be well-formed (same contract as `deserialize_unchecked`).

- On an IO error mid-operation, `self` is left in a partially-updated
  state (documented on each method).

## Performance

Measured with criterion's saved-baseline mechanism between the two bench commits (deserialize vs with serialized). 

By criterion verdict, 110 of 128 cases improved; the remaining 18 are within noise or show no change. 

Pairwise {and/or/sub/xor} with serialized, borrow represents the `*_with_serialized_unchecked` variants, compared against deser ref-ref; assign represents the `*_assign_with_serialized_unchecked` variants, compared against deser assign-ref:

| op | borrow | assign |
|---|---|---|
| intersection | -16.5% ... -71.9% | -0.6% ... -52.1% |
| union | -3.4% ... -35.6% | -3.8% ... -30.9% |
| difference | -7.7% ... -42.6% | -3.0% ... -65.3% |
| symmetric_difference | -2.0% ... -34.0% | -1.2% ... -36.0% |

Successive {and/or/sub/xor} with serialized:

| op | borrow | assign |
|---|---|---|
| intersection | -86.4% ... -95.4% | -86.1% ... -95.2% |
| union | -1.9% ... -7.7% | +0.6% ... -4.7% |
| difference | -8.3% ... -87.5% | -3.0% ... -87.8% |
| symmetric_difference | +1.6% ... -4.7% | -0.6% ... -1.9% |

## Testing

- 8 with serialized API proptests, comparing result against the materialized ops
- two RoaringTreemap entry-API proptests
- doctests for every public method
- `cargo fmt` / `clippy -D warnings` / `--no-default-features` clean

## Bench method

The branch carries two benchmark commits around the implementation
history. The earlier one runs every case with `deserialize_unchecked_from` + in-memory ops;
the later one switches to the new APIs, can reproduce with:

```bash
git checkout <baseline-commit>
cargo bench -p benchmarks --bench lib -- '(_with_serialized|With Serialized)/' --save-baseline baseline
git checkout <compare-commit>
cargo bench -p benchmarks --bench lib -- '(_with_serialized|With Serialized)/' --baseline baseline
```




## Raw results


### Pairwise Ops

| op | dataset | with_serialized | verdict | assign_with_serialized | verdict |
|---|---|---|---|---|---|
| intersection | census-income | [-18.329% -17.209% -16.250%] | improved | [-1.0136% -0.6036% -0.1812%] | noise |
| intersection | census-income_srt | [-18.515% -17.764% -16.974%] | improved | [-4.9195% -3.4260% -1.7854%] | improved |
| intersection | census1881 | [-71.509% -71.092% -70.596%] | improved | [-53.493% -52.108% -50.385%] | improved |
| intersection | census1881_srt | [-72.158% -71.880% -71.589%] | improved | [-52.427% -51.686% -50.622%] | improved |
| intersection | weather_sept_85 | [-16.638% -16.504% -16.371%] | improved | [-2.3577% -1.2703% -0.2193%] | noise |
| intersection | weather_sept_85_srt | [-27.199% -25.955% -24.748%] | improved | [-9.3538% -8.0083% -6.5750%] | improved |
| intersection | wikileaks-noquotes | [-32.230% -31.496% -30.750%] | improved | [-17.090% -16.230% -15.330%] | improved |
| intersection | wikileaks-noquotes_srt | [-38.730% -38.273% -37.836%] | improved | [-28.709% -28.382% -28.028%] | improved |
| union | census-income | [-4.5727% -3.3848% -2.5974%] | improved | [-4.3358% -3.8267% -3.2813%] | improved |
| union | census-income_srt | [-7.5361% -7.0923% -6.6297%] | improved | [-6.9721% -5.8863% -4.8113%] | improved |
| union | census1881 | [-28.169% -27.208% -26.269%] | improved | [-26.096% -23.719% -20.934%] | improved |
| union | census1881_srt | [-35.949% -35.562% -35.109%] | improved | [-31.769% -30.866% -29.970%] | improved |
| union | weather_sept_85 | [-6.4496% -5.8788% -5.5053%] | improved | [-5.6414% -5.1687% -4.7993%] | improved |
| union | weather_sept_85_srt | [-15.418% -14.432% -13.581%] | improved | [-11.273% -10.640% -10.056%] | improved |
| union | wikileaks-noquotes | [-15.941% -15.393% -14.882%] | improved | [-12.898% -12.013% -11.167%] | improved |
| union | wikileaks-noquotes_srt | [-24.545% -24.072% -23.597%] | improved | [-21.161% -20.307% -19.351%] | improved |
| difference | census-income | [-11.077% -9.0714% -7.6401%] | improved | [-4.0279% -3.2628% -2.5482%] | improved |
| difference | census-income_srt | [-9.0773% -7.9331% -6.9387%] | improved | [-3.7245% -3.0515% -2.2786%] | improved |
| difference | census1881 | [-29.184% -28.027% -26.891%] | improved | [-45.524% -44.751% -43.923%] | improved |
| difference | census1881_srt | [-43.313% -42.644% -41.954%] | improved | [-65.679% -65.320% -64.928%] | improved |
| difference | weather_sept_85 | [-8.8820% -7.6905% -5.9019%] | improved | [-3.8977% -2.9804% -1.8133%] | improved |
| difference | weather_sept_85_srt | [-11.912% -11.396% -10.906%] | improved | [-9.4996% -9.1519% -8.7834%] | improved |
| difference | wikileaks-noquotes | [-18.394% -17.818% -17.170%] | improved | [-14.739% -13.953% -12.857%] | improved |
| difference | wikileaks-noquotes_srt | [-24.802% -24.232% -23.511%] | improved | [-29.432% -28.091% -26.146%] | improved |
| symmetric_difference | census-income | [-5.3968% -4.3041% -3.2824%] | improved | [-2.7274% -1.7054% -0.4371%] | noise |
| symmetric_difference | census-income_srt | [-5.0742% -4.3538% -3.6754%] | improved | [-3.5106% -2.2603% -0.9111%] | noise |
| symmetric_difference | census1881 | [-25.423% -24.118% -22.883%] | improved | [-26.533% -24.070% -21.554%] | improved |
| symmetric_difference | census1881_srt | [-34.461% -34.006% -33.500%] | improved | [-37.767% -35.981% -34.240%] | improved |
| symmetric_difference | weather_sept_85 | [-2.5427% -2.0115% -1.3606%] | improved | [-1.7525% -1.2034% -0.4500%] | noise |
| symmetric_difference | weather_sept_85_srt | [-9.0486% -8.4635% -7.7271%] | improved | [-8.1319% -7.1411% -5.8961%] | improved |
| symmetric_difference | wikileaks-noquotes | [-12.304% -11.436% -10.255%] | improved | [-11.961% -9.8658% -7.7154%] | improved |
| symmetric_difference | wikileaks-noquotes_srt | [-21.452% -20.882% -20.415%] | improved | [-20.909% -19.811% -18.837%] | improved |

### Successive ops

| op | dataset | with_serialized | verdict | assign_with_serialized | verdict |
|---|---|---|---|---|---|
| And | census-income | [-89.643% -89.548% -89.427%] | improved | [-89.339% -89.267% -89.178%] | improved |
| And | census-income_srt | [-89.246% -89.150% -89.010%] | improved | [-89.138% -89.082% -89.004%] | improved |
| And | census1881 | [-92.646% -92.614% -92.583%] | improved | [-92.601% -92.564% -92.523%] | improved |
| And | census1881_srt | [-89.985% -89.943% -89.893%] | improved | [-89.696% -89.646% -89.588%] | improved |
| And | weather_sept_85 | [-95.402% -95.369% -95.331%] | improved | [-95.368% -95.227% -95.036%] | improved |
| And | weather_sept_85_srt | [-94.583% -94.514% -94.437%] | improved | [-94.533% -94.515% -94.494%] | improved |
| And | wikileaks-noquotes | [-88.486% -88.360% -88.140%] | improved | [-88.325% -88.269% -88.184%] | improved |
| And | wikileaks-noquotes_srt | [-86.471% -86.419% -86.359%] | improved | [-86.143% -86.068% -85.957%] | improved |
| Or | census-income | [-3.4955% -3.0132% -2.5400%] | improved | [-0.1533% +0.6266% +1.6442%] | no change |
| Or | census-income_srt | [-2.7091% -1.8549% -0.3886%] | noise | [-0.8085% -0.4998% -0.1601%] | noise |
| Or | census1881 | [-2.3503% -2.0984% -1.8419%] | improved | [-0.6523% -0.3283% +0.0048%] | noise |
| Or | census1881_srt | [-4.9840% -4.6477% -4.2982%] | improved | [-5.0289% -4.6995% -4.3871%] | improved |
| Or | weather_sept_85 | [-2.5359% -2.0416% -1.6013%] | improved | [-3.3310% -2.9617% -2.6450%] | improved |
| Or | weather_sept_85_srt | [-8.0470% -7.7016% -7.3374%] | improved | [-2.9291% -2.4083% -1.8745%] | improved |
| Or | wikileaks-noquotes | [-7.8336% -7.2011% -6.5746%] | improved | [-3.4234% -2.7691% -1.9536%] | improved |
| Or | wikileaks-noquotes_srt | [-7.2369% -6.3239% -4.9517%] | improved | [-5.0780% -4.6570% -4.1780%] | improved |
| Sub | census-income | [-69.385% -69.210% -69.040%] | improved | [-72.054% -71.659% -71.297%] | improved |
| Sub | census-income_srt | [-87.558% -87.500% -87.438%] | improved | [-87.850% -87.751% -87.658%] | improved |
| Sub | census1881 | [-73.455% -73.314% -73.121%] | improved | [-76.903% -76.649% -76.316%] | improved |
| Sub | census1881_srt | [-81.666% -81.573% -81.470%] | improved | [-86.611% -86.514% -86.433%] | improved |
| Sub | weather_sept_85 | [-57.707% -57.371% -56.986%] | improved | [-63.557% -63.288% -62.980%] | improved |
| Sub | weather_sept_85_srt | [-52.462% -52.158% -51.829%] | improved | [-58.720% -58.429% -58.016%] | improved |
| Sub | wikileaks-noquotes | [-8.5247% -8.2564% -7.9469%] | improved | [-3.4459% -2.9721% -2.3528%] | improved |
| Sub | wikileaks-noquotes_srt | [-42.907% -42.575% -42.120%] | improved | [-48.377% -48.048% -47.645%] | improved |
| Xor | census-income | [-4.8945% -3.8111% -2.9735%] | improved | [-1.0775% -0.6559% -0.2751%] | noise |
| Xor | census-income_srt | [-4.0996% -3.5904% -2.9824%] | improved | [-1.9860% -1.2840% -0.2092%] | noise |
| Xor | census1881 | [-0.6673% +0.2225% +1.2156%] | no change | [-1.1554% -0.5569% +0.1710%] | no change |
| Xor | census1881_srt | [-2.1326% -1.2332% -0.1680%] | noise | [-2.3790% -1.8990% -1.2140%] | improved |
| Xor | weather_sept_85 | [-5.4685% -4.7495% -3.9060%] | improved | [-0.9623% -0.6192% -0.1871%] | noise |
| Xor | weather_sept_85_srt | [-4.3508% -3.9842% -3.5923%] | improved | [-2.0068% -1.5944% -1.1938%] | improved |
| Xor | wikileaks-noquotes | [+0.9814% +1.5743% +2.3088%] | noise | [-1.2820% -1.0919% -0.9188%] | noise |
| Xor | wikileaks-noquotes_srt | [-1.2660% -1.0576% -0.8401%] | noise | [-1.8748% -1.4896% -1.0703%] | improved |
