### PR TITLE
Fix off-by-one that corrupts a bitmap in remove_smallest/remove_biggest (#359)

### DIFF
--- a/roaring/src/bitmap/store/interval_store.rs
+++ b/roaring/src/bitmap/store/interval_store.rs
@@ -261,7 +261,10 @@ impl IntervalStore {
             }
         }
         if let Some(last_interval) = last_interval {
-            if last_interval.run_len() < amount {
+            // `<=`, not `<`: when the amount left equals this interval's run
+            // length the whole interval is consumed and must be dropped, not
+            // shrunk to `start = end + 1` (an inverted interval) (#359).
+            if last_interval.run_len() <= amount {
                 remove_to += 1;
             } else {
                 last_interval.start += amount as u16;
@@ -285,7 +288,11 @@ impl IntervalStore {
             }
         }
         if let Some(last_interval) = last_interval {
-            if last_interval.run_len() >= amount {
+            // `>`, not `>=`: when the amount left equals this interval's run
+            // length the whole interval is consumed and is removed by the
+            // `drain` below; shrinking it would set `end = start - 1` (an
+            // inverted interval) (#359).
+            if last_interval.run_len() > amount {
                 remove_to += 1;
                 last_interval.end -= amount as u16;
             }
@@ -1655,6 +1662,31 @@ mod tests {
         ]);
         interval_store.remove_biggest(500);
         assert_eq!(interval_store, IntervalStore(alloc::vec![Interval::new_unchecked(1, 5800),]));
+    }
+
+    #[test]
+    fn remove_smallest_exact_interval_boundary() {
+        // #359: removing exactly the run length of the first interval must drop
+        // it entirely, not shrink it past its end into an inverted interval.
+        let mut interval_store = IntervalStore(alloc::vec![
+            Interval { start: 0, end: 2 },
+            Interval { start: 4, end: 4 },
+        ]);
+        interval_store.remove_smallest(3); // == run_len of [0, 2]
+        assert_eq!(interval_store, IntervalStore(alloc::vec![Interval::new_unchecked(4, 4)]));
+    }
+
+    #[test]
+    fn remove_biggest_exact_interval_boundary() {
+        // #359: removing exactly the run length of the last interval must drop
+        // it entirely, not shrink its end below its start into an inverted
+        // interval.
+        let mut interval_store = IntervalStore(alloc::vec![
+            Interval { start: 2, end: 2 },
+            Interval { start: 4, end: 8 },
+        ]);
+        interval_store.remove_biggest(5); // == run_len of [4, 8]
+        assert_eq!(interval_store, IntervalStore(alloc::vec![Interval::new_unchecked(2, 2)]));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #359.

### Problem

For a run/interval container, `IntervalStore::remove_smallest(n)` and `remove_biggest(n)` have an off-by-one at the interval where removal stops when `n` **exactly** equals that interval's run length:

- `remove_smallest` does `start += amount`, moving `start` to `end + 1`.
- `remove_biggest` does `end -= amount`, moving `end` to `start - 1`.

Either way the interval becomes inverted (`start > end`), and `run_len()` (`end - start + 1`) then underflows on the subtraction: a **debug-build panic** ("attempt to subtract with overflow"), or **silent corruption** in release. The reporter's example: `{0,1,2,4}.remove_smallest(3)` should yield `{4}` but returns a bitmap of length 65537.

### Fix

Drop the exactly-consumed interval instead of shrinking it:

- `remove_smallest`: `if last_interval.run_len() < amount` becomes `<=`, so an interval whose whole run is removed is dropped via `remove_to += 1` rather than shrunk.
- `remove_biggest`: `if last_interval.run_len() >= amount` becomes `>`, so the exactly-consumed interval falls through to the `drain(remove_to..)` that removes it, instead of shrinking its `end`.

### Test

Added `remove_smallest_exact_interval_boundary` and `remove_biggest_exact_interval_boundary` (the reporter's two cases at the `IntervalStore` level). Red-green verified with `cargo test -p roaring`: before the fix both assert against inverted intervals (`[3, 2]` / `[4, 3]`); after, they drop the whole interval. The full `roaring` test suite (including the property tests) passes; `rustfmt --check` and `clippy` are clean.
